### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/yaml-validation.yaml
+++ b/.github/workflows/yaml-validation.yaml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   validate-yaml:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: python:3.13-slim


### PR DESCRIPTION
Potential fix for [https://github.com/JSChronicles/anvil/security/code-scanning/4](https://github.com/JSChronicles/anvil/security/code-scanning/4)

In general, the problem is fixed by explicitly specifying minimal `GITHUB_TOKEN` permissions in the workflow or job definition using a `permissions:` block, rather than relying on potentially broader repository/organization defaults.

For this specific workflow, the `validate-yaml` job checks out the repository and runs schema validation against YAML files. It only needs to read repository contents; it does not create or modify any GitHub resources. The safest minimal permissions are therefore `contents: read`. To avoid changing functionality and to scope permissions to this single job only, add a `permissions:` block under `validate-yaml:` (at the same indentation level as `runs-on:`), setting `contents: read`. No other permissions appear necessary.

Concretely, edit `.github/workflows/yaml-validation.yaml` around line 15–18 to insert:
```yaml
    permissions:
      contents: read
```
between `validate-yaml:` and `runs-on: ubuntu-latest`. No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
