### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   ruff:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: python:3.13-slim


### PR DESCRIPTION
Potential fix for [https://github.com/JSChronicles/anvil/security/code-scanning/3](https://github.com/JSChronicles/anvil/security/code-scanning/3)

In general, to fix this issue, add an explicit `permissions:` block either at the top level of the workflow (to apply to all jobs) or within the specific job that needs restricted permissions. Set it to the least privileges required, for example `contents: read` for a workflow that only needs to read repository contents.

For this specific workflow (`.github/workflows/ruff.yaml`), the `ruff` job only checks out the code and runs Ruff linting and formatting locally in a container; there are no steps that push changes, open issues, or otherwise write to GitHub. Therefore, the single best fix is to add a `permissions:` block to the `ruff` job (or at the root). To minimize the change and keep the permissions clearly tied to the job CodeQL flagged, we can add:

```yaml
permissions:
  contents: read
```

under `jobs: ruff:` and above `runs-on:`. No additional imports or external dependencies are needed; this is purely a YAML configuration change.

Concretely, in `.github/workflows/ruff.yaml`, edit the `ruff` job section (around line 15–16) to insert the `permissions` mapping so that the job uses a token with read-only access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
