### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,5 +1,8 @@
 name: Python Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/JSChronicles/anvil/security/code-scanning/2](https://github.com/JSChronicles/anvil/security/code-scanning/2)

In general, the fix is to explicitly declare a restrictive `permissions` block in the workflow, granting only the scopes actually needed. For this pytest workflow, the job just needs to read the repository contents to run tests, so `contents: read` is sufficient. Declaring this at the root level applies it to all jobs by default.

The single best fix here is to add a top-level `permissions` block right after the `name:` (or before `jobs:`) in `.github/workflows/pytest.yaml` with `contents: read`. This documents that the workflow only needs read access to the repository contents and ensures the `GITHUB_TOKEN` cannot perform unintended write actions. No changes to steps, actions versions, or additional imports are needed.

Concretely, in `.github/workflows/pytest.yaml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Python Tests` line and the `on:` block (or equivalently right before `jobs:`), keeping indentation consistent with other top-level keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
