### PR TITLE
Cache organization discovery and reuse session

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.11.3
+  rev: 0.11.6
   hooks:
     - id: uv-lock
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.9
+  rev: v0.15.10
   hooks:
     # Run the linter. https://docs.astral.sh/ruff/linter/
     - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "anvil"
-version = "0.17.0"
+version = "0.18.0"
 description = "Anvil is a multi-org AWS execution runner"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/src/anvil/organization.py
+++ b/src/anvil/organization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 import boto3
+from boto3.session import Session
 
 from anvil.account import Account
 from anvil.descriptors import TargetDescriptor
@@ -24,11 +25,17 @@ class OrganizationResolver:
         context: ExecutionContext,
         management_account_id: str | None = None,
         session_factory: SessionFactory | None = None,
+        base_session: Session | None = None,
+        discovered_accounts: dict[str, dict[str, str]] | None = None,
+        enabled_regions: list[str] | None = None,
     ) -> None:
         self.descriptor = descriptor
         self.context = context
         self._management_account_id: str | None = management_account_id
         self._session_factory = session_factory or SessionFactory()
+        self._base_session = base_session
+        self._discovered_accounts = discovered_accounts
+        self._enabled_regions = enabled_regions
 
     def resolve_accounts(self) -> list[Account]:
         __LOGGER__.info(
@@ -36,11 +43,13 @@ class OrganizationResolver:
             f"(org={self.descriptor.name}, regions={self.context.regions})"
         )
 
-        base_session = self._session_factory.create_base_session(
+        base_session = self._base_session or self._session_factory.create_base_session(
             profile_name=self.descriptor.profile, region_name=self.context.regions[0]
         )
 
-        effective_regions = self._get_effective_regions(base_session)
+        effective_regions = self._get_effective_regions(
+            base_session, discovered_regions=self._enabled_regions
+        )
         if not effective_regions:
             raise ValueError("No effective configured regions remain after validation.")
 
@@ -50,21 +59,23 @@ class OrganizationResolver:
         if self._management_account_id is not None:
             management_account_id = self._management_account_id
         else:
-            management_account_id = self._get_management_account_id(base_session)
+            _, management_account_id = self.describe_organization(base_session)
 
         return self._build_accounts(
             base_session=base_session,
             management_account_id=management_account_id,
             effective_regions=effective_regions,
+            discovered_accounts=self._discovered_accounts,
         )
 
-    def _get_management_account_id(self, session: boto3.Session) -> str:
+    @staticmethod
+    def describe_organization(session: boto3.Session) -> tuple[str, str]:
         """
-        Return the management account ID for this AWS Organization.
+        Return the organization ID and management account ID.
         """
         org_client = session.client("organizations", config=BOTO_CONFIG)
         org = org_client.describe_organization()["Organization"]
-        return org["MasterAccountId"]
+        return org["Id"], org["MasterAccountId"]
 
     def _build_accounts(
         self,
@@ -72,11 +83,12 @@ class OrganizationResolver:
         base_session: boto3.Session,
         management_account_id: str,
         effective_regions: list[str],
+        discovered_accounts: dict[str, dict[str, str]] | None = None,
     ) -> list[Account]:
         """
         Build executable account objects for all selected target accounts.
         """
-        all_accounts = self._discover_accounts(base_session)
+        all_accounts = discovered_accounts or self.discover_accounts(base_session)
         target_accounts = self._filter_accounts(all_accounts)
 
         accounts: list[Account] = []
@@ -98,7 +110,8 @@ class OrganizationResolver:
 
         return accounts
 
-    def _discover_accounts(self, session: boto3.Session) -> dict[str, dict[str, str]]:
+    @staticmethod
+    def discover_accounts(session: boto3.Session) -> dict[str, dict[str, str]]:
         """
         Discover all active accounts in the organization.
         """
@@ -120,7 +133,8 @@ class OrganizationResolver:
 
         return accounts
 
-    def _discover_enabled_regions(self, session: boto3.Session) -> list[str]:
+    @staticmethod
+    def discover_enabled_regions(session: boto3.Session) -> list[str]:
         """
         Discover enabled AWS regions available to this organization context.
         """
@@ -170,12 +184,16 @@ class OrganizationResolver:
         remaining_ids = sorted(discovered_ids - exclude_set)
         return {account_id: all_accounts[account_id] for account_id in remaining_ids}
 
-    def _get_effective_regions(self, session: boto3.Session) -> list[str]:
+    def _get_effective_regions(
+        self, session: boto3.Session, *, discovered_regions: list[str] | None = None
+    ) -> list[str]:
         """
         Intersect configured regions with discovered enabled regions and warn on
         configured regions that are unavailable.
         """
-        discovered_regions = set(self._discover_enabled_regions(session))
+        discovered_regions = set(
+            discovered_regions or self.discover_enabled_regions(session)
+        )
         configured_regions = list(self.context.regions)
 
         unavailable_regions = sorted(set(configured_regions) - discovered_regions)

--- a/src/anvil/runner.py
+++ b/src/anvil/runner.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import logging
+import threading
 from collections import deque
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 
 from boto3.session import Session
 
@@ -15,7 +16,7 @@ from anvil.execution_context import ExecutionContext
 from anvil.executor import execute_accounts
 from anvil.organization import OrganizationResolver
 from anvil.results import AuthResult, EngineResult, EngineState, TargetResult
-from anvil.session import BOTO_CONFIG, SessionFactory
+from anvil.session import SessionFactory
 from anvil.task_loader import ResolvedExecution, ResolvedTask, resolve_tasks
 
 __LOGGER__ = logging.getLogger(__name__)
@@ -37,8 +38,12 @@ class PreparedTarget:
     effective_target: TargetDescriptor
     auth_result: AuthResult
     context: ExecutionContext | None
+    session_factory: SessionFactory = field(default_factory=SessionFactory)
+    base_session: Session | None = None
     organization_id: str | None = None
     management_account_id: str | None = None
+    discovered_accounts: dict[str, dict[str, str]] | None = None
+    enabled_regions: list[str] | None = None
 
     @property
     def runnable(self) -> bool:
@@ -50,6 +55,34 @@ class TargetExecutionOutcome:
     index: int
     target_result: TargetResult
     cancelled: bool
+
+
+@dataclass(frozen=True, slots=True)
+class OrganizationRunCacheEntry:
+    management_account_id: str
+    discovered_accounts: dict[str, dict[str, str]]
+    enabled_regions: list[str]
+
+
+class OrganizationRunCache:
+    def __init__(self) -> None:
+        self._entries: dict[str, OrganizationRunCacheEntry] = {}
+        self._lock = threading.Lock()
+
+    def get(self, organization_id: str) -> OrganizationRunCacheEntry | None:
+        with self._lock:
+            return self._entries.get(organization_id)
+
+    def put_if_absent(
+        self, organization_id: str, entry: OrganizationRunCacheEntry
+    ) -> OrganizationRunCacheEntry:
+        with self._lock:
+            existing = self._entries.get(organization_id)
+            if existing is not None:
+                return existing
+
+            self._entries[organization_id] = entry
+            return entry
 
 
 def _elevate_state(current: EngineState, new: EngineState) -> EngineState:
@@ -142,15 +175,47 @@ def _build_execution_context(
 
 
 def _preflight_organization(
-    *, target: TargetDescriptor, context: ExecutionContext
-) -> tuple[str, str]:
-    session_factory = SessionFactory()
+    *,
+    target: TargetDescriptor,
+    context: ExecutionContext,
+    session_factory: SessionFactory,
+    organization_cache: OrganizationRunCache,
+) -> tuple[
+    Session,
+    str,
+    str,
+    dict[str, dict[str, str]],
+    list[str],
+]:
     base_session: Session = session_factory.create_base_session(
         profile_name=target.profile, region_name=context.regions[0]
     )
-    org_client = base_session.client("organizations", config=BOTO_CONFIG)
-    organization = org_client.describe_organization()["Organization"]
-    return organization["Id"], organization["MasterAccountId"]
+    organization_id, management_account_id = OrganizationResolver.describe_organization(
+        base_session
+    )
+
+    cached_entry = organization_cache.get(organization_id)
+    if cached_entry is None:
+        cached_entry = organization_cache.put_if_absent(
+            organization_id,
+            OrganizationRunCacheEntry(
+                management_account_id=management_account_id,
+                discovered_accounts=OrganizationResolver.discover_accounts(
+                    base_session
+                ),
+                enabled_regions=OrganizationResolver.discover_enabled_regions(
+                    base_session
+                ),
+            ),
+        )
+
+    return (
+        base_session,
+        organization_id,
+        cached_entry.management_account_id,
+        cached_entry.discovered_accounts,
+        cached_entry.enabled_regions,
+    )
 
 
 def prepare_target(
@@ -160,7 +225,9 @@ def prepare_target(
     cli_dry_run: bool | None,
     cli_include: list[str] | None,
     cli_exclude: list[str] | None,
+    organization_cache: OrganizationRunCache,
 ) -> PreparedTarget:
+    session_factory = SessionFactory()
     auth_result: AuthResult = _run_auth_check_for_target(target)
     effective_target: TargetDescriptor = _build_effective_target(
         target=target,
@@ -175,6 +242,7 @@ def prepare_target(
             effective_target=effective_target,
             auth_result=auth_result,
             context=None,
+            session_factory=session_factory,
         )
 
     execution: ResolvedExecution = resolve_tasks(task_specs=effective_target.tasks)
@@ -183,11 +251,23 @@ def prepare_target(
         target=effective_target, tasks=tasks
     )
 
+    base_session: Session | None = None
     organization_id: str | None = None
     management_account_id: str | None = None
+    discovered_accounts: dict[str, dict[str, str]] | None = None
+    enabled_regions: list[str] | None = None
     if effective_target.is_organization_config:
-        organization_id, management_account_id = _preflight_organization(
-            target=effective_target, context=context
+        (
+            base_session,
+            organization_id,
+            management_account_id,
+            discovered_accounts,
+            enabled_regions,
+        ) = _preflight_organization(
+            target=effective_target,
+            context=context,
+            session_factory=session_factory,
+            organization_cache=organization_cache,
         )
 
     return PreparedTarget(
@@ -195,8 +275,12 @@ def prepare_target(
         effective_target=effective_target,
         auth_result=auth_result,
         context=context,
+        session_factory=session_factory,
+        base_session=base_session,
         organization_id=organization_id,
         management_account_id=management_account_id,
+        discovered_accounts=discovered_accounts,
+        enabled_regions=enabled_regions,
     )
 
 
@@ -212,9 +296,17 @@ def run_prepared_target(*, prepared_target: PreparedTarget) -> TargetExecutionOu
             descriptor=target,
             context=context,
             management_account_id=prepared_target.management_account_id,
+            session_factory=prepared_target.session_factory,
+            base_session=prepared_target.base_session,
+            discovered_accounts=prepared_target.discovered_accounts,
+            enabled_regions=prepared_target.enabled_regions,
         )
     else:
-        resolver = AccountResolver(descriptor=target, context=context)
+        resolver = AccountResolver(
+            descriptor=target,
+            context=context,
+            session_factory=prepared_target.session_factory,
+        )
 
     try:
         accounts: list[Account] = resolver.resolve_accounts()
@@ -306,6 +398,7 @@ def _run_target_pipeline(
     # same-organization exclusion has cleared.
     ready_targets: deque[PreparedTarget] = deque()
     active_organization_ids: set[str] = set()
+    organization_cache = OrganizationRunCache()
 
     if targets:
         worker_limit = max(1, min(max_parallel_targets, len(targets)))
@@ -322,6 +415,7 @@ def _run_target_pipeline(
                     cli_dry_run=cli_dry_run,
                     cli_include=cli_include,
                     cli_exclude=cli_exclude,
+                    organization_cache=organization_cache,
                 ): index
                 for index, target in enumerate(targets)
             }

--- a/src/anvil/runner.py
+++ b/src/anvil/runner.py
@@ -180,13 +180,7 @@ def _preflight_organization(
     context: ExecutionContext,
     session_factory: SessionFactory,
     organization_cache: OrganizationRunCache,
-) -> tuple[
-    Session,
-    str,
-    str,
-    dict[str, dict[str, str]],
-    list[str],
-]:
+) -> tuple[Session, str, str, dict[str, dict[str, str]], list[str]]:
     base_session: Session = session_factory.create_base_session(
         profile_name=target.profile, region_name=context.regions[0]
     )

--- a/tests/runner/test_runner_flow.py
+++ b/tests/runner/test_runner_flow.py
@@ -1,6 +1,14 @@
 from anvil.descriptors import ConfigBranch, TargetDescriptor
+from anvil.execution_context import ExecutionContext
 from anvil.results import AuthResult, ExecutionStatus
-from anvil.runner import run_multiple_targets
+from anvil.runner import (
+    OrganizationRunCache,
+    PreparedTarget,
+    prepare_target,
+    run_multiple_targets,
+    run_prepared_target,
+)
+from anvil.task_loader import ResolvedExecution
 
 
 def test_runner_auth_failure_short_circuits(monkeypatch):
@@ -39,3 +47,191 @@ def test_runner_auth_failure_short_circuits(monkeypatch):
     assert engine_result.auth_results[0].status is ExecutionStatus.ERROR
     assert engine_result.target_results == []
     assert engine_result.has_auth_failures
+
+
+def test_prepare_target_reuses_same_org_discovery_cache(monkeypatch):
+    discovered_accounts = {
+        "111111111111": {
+            "account_number": "111111111111",
+            "account_alias": "acct-a",
+        }
+    }
+    enabled_regions = ["us-east-1", "us-west-2"]
+    call_counts = {"accounts": 0, "regions": 0}
+
+    monkeypatch.setattr(
+        "anvil.runner._run_auth_check_for_target",
+        lambda target: AuthResult(
+            target_name=target.name,
+            status=ExecutionStatus.SUCCESS,
+            source="test",
+            started_at="start",
+            ended_at="end",
+            duration_seconds=0.0,
+            message="ok",
+        ),
+    )
+    monkeypatch.setattr(
+        "anvil.runner.resolve_tasks",
+        lambda task_specs: ResolvedExecution(ordered=[], adjacency={}),
+    )
+
+    class FakeSessionFactory:
+        def create_base_session(self, **kwargs):
+            return type("_BaseSession", (), {"profile_name": kwargs["profile_name"]})()
+
+    monkeypatch.setattr("anvil.runner.SessionFactory", FakeSessionFactory)
+    monkeypatch.setattr(
+        "anvil.runner.OrganizationResolver.describe_organization",
+        staticmethod(lambda session: ("o-shared", "999999999999")),
+    )
+
+    def fake_discover_accounts(session):
+        call_counts["accounts"] += 1
+        return discovered_accounts
+
+    def fake_discover_regions(session):
+        call_counts["regions"] += 1
+        return enabled_regions
+
+    monkeypatch.setattr(
+        "anvil.runner.OrganizationResolver.discover_accounts",
+        staticmethod(fake_discover_accounts),
+    )
+    monkeypatch.setattr(
+        "anvil.runner.OrganizationResolver.discover_enabled_regions",
+        staticmethod(fake_discover_regions),
+    )
+
+    organization_cache = OrganizationRunCache()
+    target_a = TargetDescriptor(
+        config_branch=ConfigBranch.ORGANIZATIONS,
+        name="org-a",
+        profile="shared",
+        regions=["us-east-1"],
+        tasks=[],
+    )
+    target_b = TargetDescriptor(
+        config_branch=ConfigBranch.ORGANIZATIONS,
+        name="org-b",
+        profile="shared",
+        regions=["us-west-2"],
+        tasks=[],
+    )
+
+    prepared_a = prepare_target(
+        index=0,
+        target=target_a,
+        cli_dry_run=None,
+        cli_include=None,
+        cli_exclude=None,
+        organization_cache=organization_cache,
+    )
+    prepared_b = prepare_target(
+        index=1,
+        target=target_b,
+        cli_dry_run=None,
+        cli_include=None,
+        cli_exclude=None,
+        organization_cache=organization_cache,
+    )
+
+    assert call_counts == {"accounts": 1, "regions": 1}
+    assert prepared_a.base_session is not None
+    assert prepared_b.base_session is not None
+    assert prepared_a.discovered_accounts == discovered_accounts
+    assert prepared_b.discovered_accounts == discovered_accounts
+    assert prepared_a.enabled_regions == enabled_regions
+    assert prepared_b.enabled_regions == enabled_regions
+
+
+def test_run_prepared_target_uses_cached_org_preflight(monkeypatch):
+    target = TargetDescriptor(
+        config_branch=ConfigBranch.ORGANIZATIONS,
+        name="org-a",
+        profile="shared",
+        regions=["us-east-1"],
+        tasks=[],
+        role_name="TestRole",
+    )
+    context = ExecutionContext(
+        regions=["us-east-1"],
+        role_name="TestRole",
+        dry_run=False,
+        tasks=[],
+        metadata={},
+    )
+    base_session = type("_BaseSession", (), {"profile_name": "shared"})()
+    discovered_accounts = {
+        "111111111111": {
+            "account_number": "111111111111",
+            "account_alias": "acct-a",
+        }
+    }
+    enabled_regions = ["us-east-1"]
+
+    class FakeSessionFactory:
+        def create_base_session(self, **kwargs):
+            raise AssertionError("execution should reuse the preflight base session")
+
+    monkeypatch.setattr(
+        "anvil.organization.OrganizationResolver.describe_organization",
+        staticmethod(
+            lambda session: (_ for _ in ()).throw(
+                AssertionError("execution should not rediscover organization identity")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "anvil.organization.OrganizationResolver.discover_accounts",
+        staticmethod(
+            lambda session: (_ for _ in ()).throw(
+                AssertionError("execution should not rediscover accounts")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "anvil.organization.OrganizationResolver.discover_enabled_regions",
+        staticmethod(
+            lambda session: (_ for _ in ()).throw(
+                AssertionError("execution should not rediscover enabled regions")
+            )
+        ),
+    )
+
+    monkeypatch.setattr(
+        "anvil.runner.execute_accounts",
+        lambda **kwargs: __import__("anvil.results", fromlist=["TargetResult"])
+        .TargetResult.create(
+            config_branch=kwargs["config_branch"],
+            target_name=kwargs["name"],
+            dry_run=kwargs["context"].dry_run,
+            account_results=[],
+        ),
+    )
+
+    prepared_target = PreparedTarget(
+        index=0,
+        effective_target=target,
+        auth_result=AuthResult(
+            target_name=target.name,
+            status=ExecutionStatus.SUCCESS,
+            source="test",
+            started_at="start",
+            ended_at="end",
+            duration_seconds=0.0,
+            message="ok",
+        ),
+        context=context,
+        session_factory=FakeSessionFactory(),
+        base_session=base_session,
+        organization_id="o-shared",
+        management_account_id="999999999999",
+        discovered_accounts=discovered_accounts,
+        enabled_regions=enabled_regions,
+    )
+
+    outcome = run_prepared_target(prepared_target=prepared_target)
+
+    assert outcome.target_result.target_name == "org-a"
+    assert outcome.cancelled is False

--- a/tests/runner/test_runner_flow.py
+++ b/tests/runner/test_runner_flow.py
@@ -51,10 +51,7 @@ def test_runner_auth_failure_short_circuits(monkeypatch):
 
 def test_prepare_target_reuses_same_org_discovery_cache(monkeypatch):
     discovered_accounts = {
-        "111111111111": {
-            "account_number": "111111111111",
-            "account_alias": "acct-a",
-        }
+        "111111111111": {"account_number": "111111111111", "account_alias": "acct-a"}
     }
     enabled_regions = ["us-east-1", "us-west-2"]
     call_counts = {"accounts": 0, "regions": 0}
@@ -163,10 +160,7 @@ def test_run_prepared_target_uses_cached_org_preflight(monkeypatch):
     )
     base_session = type("_BaseSession", (), {"profile_name": "shared"})()
     discovered_accounts = {
-        "111111111111": {
-            "account_number": "111111111111",
-            "account_alias": "acct-a",
-        }
+        "111111111111": {"account_number": "111111111111", "account_alias": "acct-a"}
     }
     enabled_regions = ["us-east-1"]
 
@@ -201,8 +195,9 @@ def test_run_prepared_target_uses_cached_org_preflight(monkeypatch):
 
     monkeypatch.setattr(
         "anvil.runner.execute_accounts",
-        lambda **kwargs: __import__("anvil.results", fromlist=["TargetResult"])
-        .TargetResult.create(
+        lambda **kwargs: __import__(
+            "anvil.results", fromlist=["TargetResult"]
+        ).TargetResult.create(
             config_branch=kwargs["config_branch"],
             target_name=kwargs["name"],
             dry_run=kwargs["context"].dry_run,

--- a/tests/tasks/test_task_loader_cache_integration.py
+++ b/tests/tasks/test_task_loader_cache_integration.py
@@ -58,13 +58,7 @@ def test_graph_and_run_paths_behave_the_same_with_cached_resolution(
     monkeypatch.setattr(
         runner,
         "_preflight_organization",
-        lambda **kwargs: (
-            object(),
-            "o-example",
-            "123456789012",
-            {},
-            ["us-east-1"],
-        ),
+        lambda **kwargs: (object(), "o-example", "123456789012", {}, ["us-east-1"]),
     )
 
     observed_tasks: list[list[str]] = []

--- a/tests/tasks/test_task_loader_cache_integration.py
+++ b/tests/tasks/test_task_loader_cache_integration.py
@@ -58,7 +58,13 @@ def test_graph_and_run_paths_behave_the_same_with_cached_resolution(
     monkeypatch.setattr(
         runner,
         "_preflight_organization",
-        lambda **kwargs: ("o-example", "123456789012"),
+        lambda **kwargs: (
+            object(),
+            "o-example",
+            "123456789012",
+            {},
+            ["us-east-1"],
+        ),
     )
 
     observed_tasks: list[list[str]] = []

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "anvil"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Add a thread-safe OrganizationRunCache to cache organization discovery to avoid repeated API calls.

Refactor OrganizationResolver to expose describe_organization (returns org id + master id) and make discovery helpers static; allow resolve_accounts to accept an injected base_session, discovered_accounts and enabled_regions.

Update runner to perform an organization preflight to store those on PreparedTarget, and pass session/discovery data into account resolution.

Update tests to reflect the new preflight signature and to assert that discovery is cached and reused during preparation and execution.

## Description
Provide a clear and concise description of your changes.


## Checklist
- [x] Python format, lint, and tests (`ruff` and `pytest`) were successful.
- [x] Pre-commit hooks passed locally.
- [ ] Documentation updated if needed.
- [x] Unit tests added or updated.
