### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/notify-pr-ready.yaml
+++ b/.github/workflows/notify-pr-ready.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: pr-merge-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   wait-for-checks-and-notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/JSChronicles/anvil/security/code-scanning/7](https://github.com/JSChronicles/anvil/security/code-scanning/7)

Add an explicit `permissions` block at the workflow root (applies to all jobs) with only the scopes needed by active steps. For this workflow, the active logic reads PR/check/status metadata via API and does not write anything, so `contents: read` is the safest minimal explicit baseline. This resolves the CodeQL finding while preserving behavior.

Best single fix in this file:
- Edit `.github/workflows/notify-pr-ready.yaml`
- Insert a top-level `permissions:` block between `concurrency` and `jobs` (or anywhere top-level), with:
  - `contents: read`

No imports/dependencies/methods are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
