### PR TITLE
feat: engine phase timings

### DIFF
--- a/.agents/skills/anvil-task-builder/SKILL.md
+++ b/.agents/skills/anvil-task-builder/SKILL.md
@@ -92,6 +92,40 @@ Runtime facts:
   `dry_run`, unless the task needs a renamed or transformed value for its own
   result schema.
 
+## Task Granularity And Performance
+
+Before creating or splitting inventory tasks, consider whether related data
+should be gathered together. Task boundaries are useful for reuse and clear
+failure semantics, but each task may repeat AWS client setup and list/describe
+calls inside the same account-region.
+
+Prefer separate tasks when:
+
+- The tasks have different safety profiles, especially read-only vs mutating.
+- They are commonly run independently.
+- They need different optional/fail-fast behavior.
+- A dependency relationship is meaningful to the workflow.
+- Combining them would make the result shape confusing or too broad.
+
+Consider one combined inventory task when:
+
+- The tasks are read-only.
+- They query the same AWS service in the same account-region.
+- They repeat the same list or describe operations.
+- Their outputs are normally consumed together.
+- Performance matters more than task-level granularity.
+
+For example, VPCs, VPC endpoints, and subnets are all EC2 regional inventory.
+If the goal is a network inventory report, a single task can create one EC2
+client, gather the related data once, and share in-memory results instead of
+having multiple tasks rediscover overlapping state.
+
+When overlap is present but separate tasks still make sense, prefer extracting
+small shared helper functions over duplicating AWS pagination logic. For
+benchmarking or heavy inventory tasks, consider metadata such as
+`include_details: false` so users can return counts and timings without writing
+large result payloads.
+
 ## Python And AWS Guidance
 
 - Keep task modules import-safe. Do not make AWS calls at import time.

--- a/.agents/skills/anvil-task-builder/SKILL.md
+++ b/.agents/skills/anvil-task-builder/SKILL.md
@@ -126,6 +126,18 @@ benchmarking or heavy inventory tasks, consider metadata such as
 `include_details: false` so users can return counts and timings without writing
 large result payloads.
 
+When suggesting YAML concurrency, treat `max_parallel_regions` as a targeted
+tool rather than a default speed knob. It is most likely to help tasks with
+meaningful per-region runtime, such as long paginated scans or slow regional
+service checks. It can also help a multi-task regional workflow when the tasks
+hit different AWS services, because the work is less concentrated on one
+service API path. For lightweight describe/list inventory across many accounts,
+especially multiple tasks that all call the same service, prefer
+`max_parallel_regions: 1` first because total pressure grows as
+`max_parallel_targets * max_workers * max_parallel_regions`, and regional API
+calls can become slower under that load. Recommend benchmarking the actual task
+mix before raising region concurrency.
+
 ## Python And AWS Guidance
 
 - Keep task modules import-safe. Do not make AWS calls at import time.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,12 @@ INFO     [cli.py:_write_run_results:90] Wrote summary to xxxx\xxxx\results\noop-
 }
 ```
 
+Use `--benchmark` only for performance investigations. It adds engine, target,
+account, region, and result-write timing details to result JSON, which can
+dramatically increase output size on large account, region, or task runs. Leave
+it off for normal audit/reporting runs, and enable it when comparing benchmark
+runs or looking for bottlenecks.
+
 To run multiple YAML files in one command, pass them after a single `--config-file` flag. They run sequentially in the order provided. Each YAML remains an isolated run with its own summary file, and the overall command exits non-zero if any YAML run fails.
 ```console
 anvil run --config-file ./yaml/orgs.yaml ./yaml/orgs2.yaml ./yaml/orgs3.yaml
@@ -352,6 +358,8 @@ organizations:
 ```
 
 `max_parallel_regions` defaults to `1`, which preserves serial region execution within each account. Values from `2` through `4` allow bounded parallel region execution. Approximate account-region task streams per target are `max_workers * max_parallel_regions`, before considering `max_parallel_targets`.
+
+Use `max_parallel_regions` selectively. It is most useful when each region performs heavier, independent work, such as deep inventory, long paginated scans, slow regional service checks, or multiple regional tasks that hit different AWS services. For broad lightweight inventory across many accounts, account-level parallelism is often enough; increasing region parallelism can multiply AWS API pressure and make each regional call slower, especially when several tasks all call the same service. When tuning, start with `max_parallel_regions: 1`, raise it only for tasks with meaningful per-region runtime, and benchmark the full concurrency shape: `max_parallel_targets * max_workers * max_parallel_regions`.
 
 You can run `--include`, `--exclude`, or `--dry-run` to override the YAML file if you want to just test something or run on certain accounts.
 ```console

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,8 @@ Task execution then occurs per account and per region, and task results include 
 
 By default, regions execute serially within each account. A target can set `max_parallel_regions` from `1` through `4` to run multiple regions for the same account concurrently while preserving task dependency order inside each region.
 
+Use parallel regions for workloads where each region has enough independent work to benefit from overlap, such as long paginated inventory, deep regional checks, slow service-specific scans, or multiple regional tasks that call different AWS services. For lightweight describe/list tasks across many accounts, region parallelism can increase AWS API pressure enough that each regional call slows down. This is especially likely when several tasks all call the same AWS service, such as multiple EC2 inventory tasks. In those cases, leave `max_parallel_regions` at `1` and rely first on account-level concurrency.
+
 Region scheduling is intentionally strict. Anvil only starts up to `max_parallel_regions` regions at a time for one account. If a non-optional task fails in one region, regions that have not started are left unstarted, while already-running regions stop cooperatively before their next task.
 
 Even when regions finish out of order, task results are returned in configured region order and then task order.
@@ -81,7 +83,7 @@ This keeps execution scalable across many accounts while avoiding unbounded conc
 
 Account work is submitted to the account worker pool up front, and the executor runs up to `max_workers` accounts at a time. If fail-fast is enabled, Anvil signals cancellation and cancels pending account futures where possible. Accounts already running stop cooperatively when they observe the cancellation signal before starting another task.
 
-When `max_parallel_regions` is greater than `1`, approximate account-region task streams per target are `max_workers * max_parallel_regions`, before considering `max_parallel_targets`.
+When `max_parallel_regions` is greater than `1`, approximate account-region task streams per target are `max_workers * max_parallel_regions`, before considering `max_parallel_targets`. Across multiple targets, the rough upper bound is `max_parallel_targets * max_workers * max_parallel_regions`, so benchmark changes with the same target count and task mix you plan to run in production.
 
 ### Fail-fast behavior and cancellation
 
@@ -113,6 +115,13 @@ Anvil records structured results at four layers:
   - Summarize the entire multi-organization run.
 
 This helps humans review and makes downstream machine processing easier.
+
+Benchmark output is diagnostic and intentionally more verbose than normal
+results. Use `anvil run --benchmark` when comparing performance, tuning
+concurrency, or looking for bottlenecks. Avoid enabling it for routine
+audit/reporting runs because it adds engine, target, account, region, and
+result-write timings that can dramatically increase result JSON size on large
+runs.
 
 ### Session and credential model
 

--- a/src/anvil/account.py
+++ b/src/anvil/account.py
@@ -89,10 +89,7 @@ class Account:
             assumed_credentials: AssumedRoleCredentials | None = None
             recorder = BenchmarkRecorder(enabled=self._context.benchmark_enabled)
             recorder.update(
-                {
-                    "assume_role_seconds": 0.0,
-                    "direct_access_validation_seconds": 0.0,
-                }
+                {"assume_role_seconds": 0.0, "direct_access_validation_seconds": 0.0}
             )
 
             if self._assume_role:

--- a/src/anvil/account.py
+++ b/src/anvil/account.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 import boto3
 from boto3.session import Session
 
+from anvil.benchmark import BenchmarkRecorder
 from anvil.execution_context import ExecutionContext
 from anvil.results import AccountResult, ExecutionStatus, TaskResult
 from anvil.session import AssumedRoleCredentials, SessionFactory
@@ -31,6 +32,7 @@ class RegionExecutionOutcome:
     task_results: list[TaskResult]
     interrupted: bool
     failed: bool
+    duration_seconds: float
 
 
 class Account:
@@ -85,19 +87,41 @@ class Account:
 
         try:
             assumed_credentials: AssumedRoleCredentials | None = None
+            recorder = BenchmarkRecorder(enabled=self._context.benchmark_enabled)
+            recorder.update(
+                {
+                    "assume_role_seconds": 0.0,
+                    "direct_access_validation_seconds": 0.0,
+                }
+            )
 
             if self._assume_role:
-                assumed_credentials: AssumedRoleCredentials = (
-                    self._get_assumed_role_credentials()
-                )
+                with recorder.phase("assume_role_seconds"):
+                    assumed_credentials: AssumedRoleCredentials = (
+                        self._get_assumed_role_credentials()
+                    )
             else:
-                self._validate_direct_account_access()
+                with recorder.phase("direct_access_validation_seconds"):
+                    self._validate_direct_account_access()
 
             account_cancel_event = threading.Event()
-            region_outcomes = self._execute_regions(
-                assumed_credentials=assumed_credentials,
-                optional_map=optional_map,
-                account_cancel_event=account_cancel_event,
+            with recorder.phase("region_execution_seconds"):
+                region_outcomes = self._execute_regions(
+                    assumed_credentials=assumed_credentials,
+                    optional_map=optional_map,
+                    account_cancel_event=account_cancel_event,
+                )
+            recorder.set(
+                "regions",
+                {
+                    outcome.region: {
+                        "duration_seconds": outcome.duration_seconds,
+                        "task_count": len(outcome.task_results),
+                        "interrupted": outcome.interrupted,
+                        "failed": outcome.failed,
+                    }
+                    for outcome in region_outcomes
+                },
             )
             for outcome in region_outcomes:
                 task_results.extend(outcome.task_results)
@@ -120,6 +144,7 @@ class Account:
                 ended_at=ended_at,
                 duration_seconds=ended_perf - started_perf,
                 tasks=task_results,
+                benchmark=recorder.data,
             )
 
         except Exception as error:
@@ -272,6 +297,9 @@ class Account:
         account_cancel_event: threading.Event,
         actions: ActionRecorder | None = None,
     ) -> RegionExecutionOutcome:
+        region_started = (
+            time.perf_counter() if self._context.benchmark_enabled else None
+        )
         session: Session = self._get_region_session(
             region=region, assumed_credentials=assumed_credentials
         )
@@ -390,6 +418,11 @@ class Account:
             task_results=task_results,
             interrupted=interrupted,
             failed=non_optional_region_failure,
+            duration_seconds=(
+                time.perf_counter() - region_started
+                if region_started is not None
+                else 0.0
+            ),
         )
 
     def _sort_task_results(self, task_results: list[TaskResult]) -> None:

--- a/src/anvil/benchmark.py
+++ b/src/anvil/benchmark.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+
+class BenchmarkRecorder:
+    """
+    Small opt-in recorder for benchmark phase timings and metadata.
+    """
+
+    def __init__(
+        self, *, enabled: bool = False, data: dict[str, object] | None = None
+    ) -> None:
+        self._data = data if data is not None else ({} if enabled else None)
+
+    @property
+    def enabled(self) -> bool:
+        return self._data is not None
+
+    @property
+    def data(self) -> dict[str, object] | None:
+        return self._data
+
+    @contextmanager
+    def phase(self, name: str) -> Iterator[None]:
+        if self._data is None:
+            yield
+            return
+
+        started = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._data[name] = time.perf_counter() - started
+
+    def set(self, name: str, value: object) -> None:
+        if self._data is not None:
+            self._data[name] = value
+
+    def pop(self, name: str) -> object | None:
+        if self._data is None:
+            return None
+
+        return self._data.pop(name, None)
+
+    def update(self, values: dict[str, object]) -> None:
+        if self._data is not None:
+            self._data.update(values)

--- a/src/anvil/cli.py
+++ b/src/anvil/cli.py
@@ -276,7 +276,10 @@ def main() -> None:
     run_parser.add_argument(
         "--benchmark",
         action="store_true",
-        help="Include engine and target phase timing details in result JSON",
+        help=(
+            "Include diagnostic phase timings in result JSON. "
+            "This can significantly increase output size."
+        ),
     )
     run_parser.set_defaults(func=_cmd_run)
 

--- a/src/anvil/cli.py
+++ b/src/anvil/cli.py
@@ -10,6 +10,7 @@ import logging
 from pathlib import Path
 from anvil.graph import render_graph
 import yaml
+from anvil.benchmark import BenchmarkRecorder
 from anvil.descriptors import LoadedConfig
 from anvil.results import EngineResult, EngineState
 from anvil.runner import run_auth_checks, run_multiple_targets
@@ -81,19 +82,42 @@ def _write_run_results(*, config_file: Path, engine_result) -> None:
     results_dir = Path.cwd() / "results"
     results_dir.mkdir(exist_ok=True)
 
-    summary = engine_result.build_summary()
+    recorder = BenchmarkRecorder(enabled=engine_result.benchmark is not None)
+    target_files: list[dict[str, object]] = []
 
     for target_result in engine_result.target_results:
         safe_name = target_result.target_name.replace("/", "_").replace(" ", "_")
         result_file = results_dir / f"{safe_name}.json"
 
-        with result_file.open("w", encoding="utf-8") as handle:
-            json.dump(target_result.to_dict(), handle, indent=2)
+        with recorder.phase("serialization_seconds"):
+            target_json = json.dumps(target_result.to_dict(), indent=2)
+        target_serialize_seconds = recorder.pop("serialization_seconds")
 
+        with recorder.phase("write_seconds"):
+            with result_file.open("w", encoding="utf-8") as handle:
+                handle.write(target_json)
+        target_write_seconds = recorder.pop("write_seconds")
+        if recorder.enabled:
+            target_files.append(
+                {
+                    "target": target_result.target_name,
+                    "serialization_seconds": target_serialize_seconds,
+                    "write_seconds": target_write_seconds,
+                    "bytes": len(target_json.encode("utf-8")),
+                }
+            )
+
+    if engine_result.benchmark is not None:
+        engine_result.benchmark["result_write"] = {
+            "target_files": target_files,
+        }
+
+    summary = engine_result.build_summary()
     summary_path = results_dir / f"{config_file.stem}-target-summary.json"
 
+    summary_json = json.dumps(summary, indent=2)
     with summary_path.open("w", encoding="utf-8") as handle:
-        json.dump(summary, handle, indent=2)
+        handle.write(summary_json)
 
     __LOGGER__.info(
         f"Wrote summary to {summary_path} and "
@@ -111,6 +135,7 @@ def _run_single_config_file(*, config_file: Path, args) -> int:
         cli_dry_run=args.dry_run,
         cli_include=args.include,
         cli_exclude=args.exclude,
+        benchmark_enabled=getattr(args, "benchmark", False),
     )
     _write_run_results(config_file=config_file, engine_result=engine_result)
 
@@ -249,6 +274,11 @@ def main() -> None:
         action="store_true",
         default=None,
         help="Run without making changes",
+    )
+    run_parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Include engine and target phase timing details in result JSON",
     )
     run_parser.set_defaults(func=_cmd_run)
 

--- a/src/anvil/cli.py
+++ b/src/anvil/cli.py
@@ -108,9 +108,7 @@ def _write_run_results(*, config_file: Path, engine_result) -> None:
             )
 
     if engine_result.benchmark is not None:
-        engine_result.benchmark["result_write"] = {
-            "target_files": target_files,
-        }
+        engine_result.benchmark["result_write"] = {"target_files": target_files}
 
     summary = engine_result.build_summary()
     summary_path = results_dir / f"{config_file.stem}-target-summary.json"

--- a/src/anvil/execution_context.py
+++ b/src/anvil/execution_context.py
@@ -20,5 +20,6 @@ class ExecutionContext:
 
     fail_fast: bool = False
     max_parallel_regions: int = 1
+    benchmark_enabled: bool = False
     log_level: str | int | None = None
     cancel_event: threading.Event = field(default_factory=threading.Event)

--- a/src/anvil/executor.py
+++ b/src/anvil/executor.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import datetime
 import logging
 from concurrent.futures import CancelledError, ThreadPoolExecutor, as_completed
 from concurrent.futures._base import Future
 
+from anvil.benchmark import BenchmarkRecorder
 from anvil.account import Account
 from anvil.descriptors import ConfigBranch
 from anvil.execution_context import ExecutionContext
@@ -19,56 +21,113 @@ def execute_accounts(
     max_workers: int,
     context: ExecutionContext,
     accounts: list[Account],
+    benchmark_enabled: bool = False,
+    benchmark: dict[str, object] | None = None,
 ) -> TargetResult:
     """
     Execute a resolved set of accounts using the shared concurrent account path.
     """
     account_results: list[AccountResult] = []
+    recorder = BenchmarkRecorder(enabled=benchmark_enabled)
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures: dict[Future[AccountResult], Account] = {
-            executor.submit(account.execute): account for account in accounts
-        }
-        fail_fast_triggered = False
+    with recorder.phase("account_execution_seconds"):
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures: dict[Future[AccountResult], Account] = {
+                executor.submit(account.execute): account for account in accounts
+            }
+            fail_fast_triggered = False
 
-        try:
-            for future in as_completed(futures):
-                try:
-                    account_result: AccountResult = future.result()
-                except CancelledError:
-                    continue
+            try:
+                for future in as_completed(futures):
+                    try:
+                        account_result: AccountResult = future.result()
+                    except CancelledError:
+                        continue
 
-                account_results.append(account_result)
+                    account_results.append(account_result)
 
-                if (
-                    context.fail_fast
-                    and account_result.status.is_unsuccessful
-                    and not fail_fast_triggered
-                ):
-                    __LOGGER__.critical(f"Fail-fast triggered in '{name}'")
+                    if (
+                        context.fail_fast
+                        and account_result.status.is_unsuccessful
+                        and not fail_fast_triggered
+                    ):
+                        __LOGGER__.critical(f"Fail-fast triggered in '{name}'")
 
-                    # Fail-fast is cooperative: pending futures are cancelled
-                    # here, while already-running account work observes
-                    # context.cancel_event and stops at its next cancellation
-                    # check.
-                    context.cancel_event.set()
-                    fail_fast_triggered = True
+                        # Fail-fast is cooperative: pending futures are cancelled
+                        # here, while already-running account work observes
+                        # context.cancel_event and stops at its next cancellation
+                        # check.
+                        context.cancel_event.set()
+                        fail_fast_triggered = True
 
-                    for pending in futures:
-                        if not pending.done():
-                            pending.cancel()
+                        for pending in futures:
+                            if not pending.done():
+                                pending.cancel()
 
-        except Exception:
-            executor.shutdown(cancel_futures=True)
-            raise
+            except Exception:
+                executor.shutdown(cancel_futures=True)
+                raise
 
     account_results.sort(
         key=lambda result: (result.account_alias.lower(), result.account_id)
     )
+
+    if benchmark_enabled:
+        account_window_seconds = _account_window_seconds(account_results)
+        sum_account_duration_seconds = sum(
+            result.duration_seconds for result in account_results
+        )
+        recorder.update(
+            {
+                "submitted_account_count": len(accounts),
+                "completed_account_count": len(account_results),
+                "max_workers": max_workers,
+                "account_execution_window_seconds": account_window_seconds,
+                "sum_account_duration_seconds": sum_account_duration_seconds,
+                "max_account_duration_seconds": max(
+                    (result.duration_seconds for result in account_results),
+                    default=0.0,
+                ),
+                "worker_utilization": _worker_utilization(
+                    sum_account_duration_seconds=sum_account_duration_seconds,
+                    max_workers=max_workers,
+                    account_window_seconds=account_window_seconds,
+                ),
+            }
+        )
+
+    target_benchmark: dict[str, object] | None = None
+    recorder_data = recorder.data
+    if recorder_data is not None:
+        target_benchmark = {**(benchmark or {}), **recorder_data}
 
     return TargetResult.create(
         config_branch=config_branch,
         target_name=name,
         dry_run=context.dry_run,
         account_results=account_results,
+        benchmark=target_benchmark,
     )
+
+
+def _account_window_seconds(account_results: list[AccountResult]) -> float:
+    if not account_results:
+        return 0.0
+
+    starts = [
+        datetime.datetime.fromisoformat(result.started_at) for result in account_results
+    ]
+    ends = [datetime.datetime.fromisoformat(result.ended_at) for result in account_results]
+    return (max(ends) - min(starts)).total_seconds()
+
+
+def _worker_utilization(
+    *,
+    sum_account_duration_seconds: float,
+    max_workers: int,
+    account_window_seconds: float,
+) -> float:
+    if max_workers <= 0 or account_window_seconds <= 0:
+        return 0.0
+
+    return sum_account_duration_seconds / (max_workers * account_window_seconds)

--- a/src/anvil/executor.py
+++ b/src/anvil/executor.py
@@ -85,8 +85,7 @@ def execute_accounts(
                 "account_execution_window_seconds": account_window_seconds,
                 "sum_account_duration_seconds": sum_account_duration_seconds,
                 "max_account_duration_seconds": max(
-                    (result.duration_seconds for result in account_results),
-                    default=0.0,
+                    (result.duration_seconds for result in account_results), default=0.0
                 ),
                 "worker_utilization": _worker_utilization(
                     sum_account_duration_seconds=sum_account_duration_seconds,
@@ -117,7 +116,9 @@ def _account_window_seconds(account_results: list[AccountResult]) -> float:
     starts = [
         datetime.datetime.fromisoformat(result.started_at) for result in account_results
     ]
-    ends = [datetime.datetime.fromisoformat(result.ended_at) for result in account_results]
+    ends = [
+        datetime.datetime.fromisoformat(result.ended_at) for result in account_results
+    ]
     return (max(ends) - min(starts)).total_seconds()
 
 

--- a/src/anvil/results.py
+++ b/src/anvil/results.py
@@ -109,9 +109,10 @@ class AccountResult(TimedResult):
     status: ExecutionStatus
     tasks: list[TaskResult]
     error: str | None = None
+    benchmark: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "account_id": self.account_id,
             "account_alias": self.account_alias,
             "status": self.status.value,
@@ -121,6 +122,10 @@ class AccountResult(TimedResult):
             "tasks": [task.to_dict() for task in self.tasks],
             "error": self.error,
         }
+        if self.benchmark is not None:
+            payload["benchmark"] = self.benchmark
+
+        return payload
 
 
 @dataclass(frozen=True, slots=True)
@@ -131,6 +136,7 @@ class TargetResult:
     dry_run: bool
     account_results: list[AccountResult]
     error: str | None = None
+    benchmark: dict[str, object] | None = None
 
     @property
     def total_accounts(self) -> int:
@@ -161,7 +167,7 @@ class TargetResult:
     def to_dict(self) -> dict[str, object]:
         singular_key, _ = _result_labels(self.config_branch)
 
-        return {
+        payload: dict[str, object] = {
             singular_key: self.target_name,
             "generated_at": self.generated_at,
             "dry_run": self.dry_run,
@@ -169,6 +175,10 @@ class TargetResult:
             "account_results": [result.to_dict() for result in self.account_results],
             "error": self.error,
         }
+        if self.benchmark is not None:
+            payload["benchmark"] = self.benchmark
+
+        return payload
 
     @classmethod
     def create(
@@ -179,6 +189,7 @@ class TargetResult:
         dry_run: bool,
         account_results: list[AccountResult],
         error: str | None = None,
+        benchmark: dict[str, object] | None = None,
     ) -> TargetResult:
         return cls(
             config_branch=config_branch,
@@ -187,6 +198,7 @@ class TargetResult:
             dry_run=dry_run,
             account_results=account_results,
             error=error,
+            benchmark=benchmark,
         )
 
 
@@ -201,6 +213,7 @@ class EngineResult:
     generated_at: str
     auth_results: list[AuthResult]
     target_results: list[TargetResult]
+    benchmark: dict[str, object] | None = None
 
     @property
     def has_auth_failures(self) -> bool:
@@ -226,7 +239,7 @@ class EngineResult:
     def to_dict(self) -> dict[str, object]:
         _, plural_key = _result_labels(self.config_branch)
 
-        return {
+        payload: dict[str, object] = {
             "state": self.state.value,
             "generated_at": self.generated_at,
             "auth": [
@@ -237,6 +250,10 @@ class EngineResult:
                 target_result.to_dict() for target_result in self.target_results
             ],
         }
+        if self.benchmark is not None:
+            payload["benchmark"] = self.benchmark
+
+        return payload
 
     @classmethod
     def create(
@@ -246,6 +263,7 @@ class EngineResult:
         state: EngineState,
         auth_results: list[AuthResult],
         target_results: list[TargetResult],
+        benchmark: dict[str, object] | None = None,
     ) -> EngineResult:
         return cls(
             config_branch=config_branch,
@@ -253,6 +271,7 @@ class EngineResult:
             generated_at=datetime.datetime.now(datetime.UTC).isoformat(),
             auth_results=auth_results,
             target_results=target_results,
+            benchmark=benchmark,
         )
 
     def build_summary(self) -> dict[str, object]:
@@ -304,10 +323,15 @@ class EngineResult:
                     "failed_tasks": failed_tasks,
                     "has_failures": target_result.has_failures,
                     "error": target_result.error,
+                    **(
+                        {"benchmark": target_result.benchmark}
+                        if target_result.benchmark is not None
+                        else {}
+                    ),
                 }
             )
 
-        return {
+        payload: dict[str, object] = {
             "state": self.state.value,
             "generated_at": self.generated_at,
             "auth": auth_results,
@@ -316,3 +340,7 @@ class EngineResult:
             "total_interrupted_accounts": total_interrupted_accounts,
             "total_failed_tasks": total_failed_tasks,
         }
+        if self.benchmark is not None:
+            payload["benchmark"] = self.benchmark
+
+        return payload

--- a/src/anvil/runner.py
+++ b/src/anvil/runner.py
@@ -568,10 +568,7 @@ def run_multiple_targets(
             benchmark_enabled=benchmark_enabled,
         )
     recorder.update(
-        {
-            "max_parallel_targets": max_parallel_targets,
-            "target_count": len(targets),
-        }
+        {"max_parallel_targets": max_parallel_targets, "target_count": len(targets)}
     )
 
     return EngineResult.create(

--- a/src/anvil/runner.py
+++ b/src/anvil/runner.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field, replace
 
 from boto3.session import Session
 
+from anvil.benchmark import BenchmarkRecorder
 from anvil.account import Account
 from anvil.account_resolver import AccountResolver
 from anvil.auth import AuthSource, auth_check, infer_auth_source
@@ -44,6 +45,7 @@ class PreparedTarget:
     management_account_id: str | None = None
     discovered_accounts: dict[str, dict[str, str]] | None = None
     enabled_regions: list[str] | None = None
+    benchmark: dict[str, object] | None = None
 
     @property
     def runnable(self) -> bool:
@@ -162,7 +164,7 @@ def _build_effective_target(
 
 
 def _build_execution_context(
-    *, target: TargetDescriptor, tasks: list[ResolvedTask]
+    *, target: TargetDescriptor, tasks: list[ResolvedTask], benchmark_enabled: bool
 ) -> ExecutionContext:
     return ExecutionContext(
         regions=target.regions,
@@ -172,6 +174,7 @@ def _build_execution_context(
         metadata=target.metadata,
         fail_fast=target.fail_fast,
         max_parallel_regions=target.max_parallel_regions,
+        benchmark_enabled=benchmark_enabled,
     )
 
 
@@ -181,28 +184,41 @@ def _preflight_organization(
     context: ExecutionContext,
     session_factory: SessionFactory,
     organization_cache: OrganizationRunCache,
+    benchmark: dict[str, object] | None = None,
 ) -> tuple[Session, str, str, dict[str, dict[str, str]], list[str]]:
-    base_session: Session = session_factory.create_base_session(
-        profile_name=target.profile, region_name=context.regions[0]
-    )
-    organization_id, management_account_id = OrganizationResolver.describe_organization(
-        base_session
-    )
+    sink = BenchmarkRecorder(data=benchmark)
+
+    with sink.phase("create_base_session_seconds"):
+        base_session: Session = session_factory.create_base_session(
+            profile_name=target.profile, region_name=context.regions[0]
+        )
+
+    with sink.phase("describe_organization_seconds"):
+        organization_id, management_account_id = (
+            OrganizationResolver.describe_organization(base_session)
+        )
 
     cached_entry = organization_cache.get(organization_id)
     if cached_entry is None:
+        with sink.phase("discover_accounts_seconds"):
+            discovered_accounts = OrganizationResolver.discover_accounts(base_session)
+
+        with sink.phase("discover_enabled_regions_seconds"):
+            enabled_regions = OrganizationResolver.discover_enabled_regions(
+                base_session
+            )
+
         cached_entry = organization_cache.put_if_absent(
             organization_id,
             OrganizationRunCacheEntry(
                 management_account_id=management_account_id,
-                discovered_accounts=OrganizationResolver.discover_accounts(
-                    base_session
-                ),
-                enabled_regions=OrganizationResolver.discover_enabled_regions(
-                    base_session
-                ),
+                discovered_accounts=discovered_accounts,
+                enabled_regions=enabled_regions,
             ),
         )
+        sink.set("organization_cache_hit", False)
+    else:
+        sink.set("organization_cache_hit", True)
 
     return (
         base_session,
@@ -221,49 +237,60 @@ def prepare_target(
     cli_include: list[str] | None,
     cli_exclude: list[str] | None,
     organization_cache: OrganizationRunCache,
+    benchmark_enabled: bool = False,
 ) -> PreparedTarget:
+    recorder = BenchmarkRecorder(enabled=benchmark_enabled)
     session_factory = SessionFactory()
-    auth_result: AuthResult = _run_auth_check_for_target(target)
-    effective_target: TargetDescriptor = _build_effective_target(
-        target=target,
-        cli_dry_run=cli_dry_run,
-        cli_include=cli_include,
-        cli_exclude=cli_exclude,
-    )
 
-    if auth_result.is_error:
-        return PreparedTarget(
-            index=index,
-            effective_target=effective_target,
-            auth_result=auth_result,
-            context=None,
-            session_factory=session_factory,
+    with recorder.phase("prepare_target_seconds"):
+        auth_result: AuthResult = _run_auth_check_for_target(target)
+
+        effective_target: TargetDescriptor = _build_effective_target(
+            target=target,
+            cli_dry_run=cli_dry_run,
+            cli_include=cli_include,
+            cli_exclude=cli_exclude,
         )
 
-    execution: ResolvedExecution = resolve_tasks(task_specs=effective_target.tasks)
-    tasks: list[ResolvedTask] = execution.ordered
-    context: ExecutionContext = _build_execution_context(
-        target=effective_target, tasks=tasks
-    )
+        if auth_result.is_error:
+            return PreparedTarget(
+                index=index,
+                effective_target=effective_target,
+                auth_result=auth_result,
+                context=None,
+                session_factory=session_factory,
+                benchmark=recorder.data,
+            )
 
-    base_session: Session | None = None
-    organization_id: str | None = None
-    management_account_id: str | None = None
-    discovered_accounts: dict[str, dict[str, str]] | None = None
-    enabled_regions: list[str] | None = None
-    if effective_target.is_organization_config:
-        (
-            base_session,
-            organization_id,
-            management_account_id,
-            discovered_accounts,
-            enabled_regions,
-        ) = _preflight_organization(
-            target=effective_target,
-            context=context,
-            session_factory=session_factory,
-            organization_cache=organization_cache,
+        with recorder.phase("resolve_tasks_seconds"):
+            execution: ResolvedExecution = resolve_tasks(
+                task_specs=effective_target.tasks
+            )
+            tasks: list[ResolvedTask] = execution.ordered
+
+        context: ExecutionContext = _build_execution_context(
+            target=effective_target, tasks=tasks, benchmark_enabled=benchmark_enabled
         )
+
+        base_session: Session | None = None
+        organization_id: str | None = None
+        management_account_id: str | None = None
+        discovered_accounts: dict[str, dict[str, str]] | None = None
+        enabled_regions: list[str] | None = None
+        if effective_target.is_organization_config:
+            (
+                base_session,
+                organization_id,
+                management_account_id,
+                discovered_accounts,
+                enabled_regions,
+            ) = _preflight_organization(
+                target=effective_target,
+                context=context,
+                session_factory=session_factory,
+                organization_cache=organization_cache,
+                benchmark=recorder.data,
+            )
 
     return PreparedTarget(
         index=index,
@@ -276,6 +303,7 @@ def prepare_target(
         management_account_id=management_account_id,
         discovered_accounts=discovered_accounts,
         enabled_regions=enabled_regions,
+        benchmark=recorder.data,
     )
 
 
@@ -304,7 +332,26 @@ def run_prepared_target(*, prepared_target: PreparedTarget) -> TargetExecutionOu
         )
 
     try:
-        accounts: list[Account] = resolver.resolve_accounts()
+        benchmark_data = (
+            dict(prepared_target.benchmark)
+            if prepared_target.benchmark is not None
+            else None
+        )
+        sink = BenchmarkRecorder(data=benchmark_data)
+        with sink.phase("resolve_accounts_seconds"):
+            accounts: list[Account] = resolver.resolve_accounts()
+
+        sink.update(
+            {
+                "resolved_account_count": len(accounts),
+                "max_workers": target.max_workers,
+                "max_parallel_regions": context.max_parallel_regions,
+                "account_region_limit": (
+                    target.max_workers * context.max_parallel_regions
+                ),
+            }
+        )
+
         account_region_limit = target.max_workers * context.max_parallel_regions
         __LOGGER__.info(
             f"Target '{target.name}' concurrency: "
@@ -318,6 +365,8 @@ def run_prepared_target(*, prepared_target: PreparedTarget) -> TargetExecutionOu
             max_workers=target.max_workers,
             context=context,
             accounts=accounts,
+            benchmark_enabled=sink.enabled,
+            benchmark=benchmark_data,
         )
     except ValueError as error:
         target_result: TargetResult = TargetResult.create(
@@ -388,6 +437,7 @@ def _run_target_pipeline(
     cli_dry_run: bool | None,
     cli_include: list[str] | None,
     cli_exclude: list[str] | None,
+    benchmark_enabled: bool = False,
 ) -> tuple[list[AuthResult], list[TargetResult], EngineState]:
 
     # Preparation and execution complete out of order, but final EngineResult
@@ -418,6 +468,7 @@ def _run_target_pipeline(
                     cli_include=cli_include,
                     cli_exclude=cli_exclude,
                     organization_cache=organization_cache,
+                    benchmark_enabled=benchmark_enabled,
                 ): index
                 for index, target in enumerate(targets)
             }
@@ -501,16 +552,26 @@ def run_multiple_targets(
     cli_dry_run: bool | None,
     cli_include: list[str] | None,
     cli_exclude: list[str] | None,
+    benchmark_enabled: bool = False,
 ) -> EngineResult:
     config_branch: ConfigBranch = (
         targets[0].config_branch if targets else ConfigBranch.ORGANIZATIONS
     )
-    auth_results, target_results, engine_state = _run_target_pipeline(
-        targets=targets,
-        max_parallel_targets=max_parallel_targets,
-        cli_dry_run=cli_dry_run,
-        cli_include=cli_include,
-        cli_exclude=cli_exclude,
+    recorder = BenchmarkRecorder(enabled=benchmark_enabled)
+    with recorder.phase("run_multiple_targets_seconds"):
+        auth_results, target_results, engine_state = _run_target_pipeline(
+            targets=targets,
+            max_parallel_targets=max_parallel_targets,
+            cli_dry_run=cli_dry_run,
+            cli_include=cli_include,
+            cli_exclude=cli_exclude,
+            benchmark_enabled=benchmark_enabled,
+        )
+    recorder.update(
+        {
+            "max_parallel_targets": max_parallel_targets,
+            "target_count": len(targets),
+        }
     )
 
     return EngineResult.create(
@@ -518,4 +579,5 @@ def run_multiple_targets(
         state=engine_state,
         auth_results=auth_results,
         target_results=target_results,
+        benchmark=recorder.data,
     )

--- a/src/anvil/tasks/count_subnets_with_timings.py
+++ b/src/anvil/tasks/count_subnets_with_timings.py
@@ -51,9 +51,7 @@ def _get_subnet_details(ec2_client) -> tuple[list[dict[str, object]], int]:
                     "available_ip_address_count": subnet.get(
                         "AvailableIpAddressCount", 0
                     ),
-                    "map_public_ip_on_launch": subnet.get(
-                        "MapPublicIpOnLaunch", False
-                    ),
+                    "map_public_ip_on_launch": subnet.get("MapPublicIpOnLaunch", False),
                 }
             )
 
@@ -109,15 +107,11 @@ def run(
     )
 
     actions.record(
-        f"Counted {len(subnets)} subnet(s) in account {account_id} "
-        f"region {region_name}"
+        f"Counted {len(subnets)} subnet(s) in account {account_id} region {region_name}"
     )
 
     return {
-        "summary": {
-            "total_subnets": len(subnets),
-            "total_vpcs": len(vpc_ids),
-        },
+        "summary": {"total_subnets": len(subnets), "total_vpcs": len(vpc_ids)},
         "subnets": subnets,
         "timing": timing,
     }

--- a/src/anvil/tasks/count_subnets_with_timings.py
+++ b/src/anvil/tasks/count_subnets_with_timings.py
@@ -1,0 +1,123 @@
+"""
+Count subnets in the current execution region with timing instrumentation.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from anvil.actions import ActionRecorder
+
+__LOGGER__ = logging.getLogger(__name__)
+
+
+def _elapsed_seconds(start: float) -> float:
+    return round(time.perf_counter() - start, 3)
+
+
+def _page_retry_attempts(page: dict[str, object]) -> int:
+    response_metadata = page.get("ResponseMetadata", {})
+    if not isinstance(response_metadata, dict):
+        return 0
+
+    retry_attempts = response_metadata.get("RetryAttempts", 0)
+    if not isinstance(retry_attempts, int):
+        return 0
+
+    return retry_attempts
+
+
+def _get_subnet_details(ec2_client) -> tuple[list[dict[str, object]], int]:
+    subnets: list[dict[str, object]] = []
+    retry_attempts = 0
+    paginator = ec2_client.get_paginator("describe_subnets")
+
+    for page in paginator.paginate():
+        retry_attempts += _page_retry_attempts(page)
+
+        for subnet in page.get("Subnets", []):
+            subnet_id = subnet.get("SubnetId")
+            vpc_id = subnet.get("VpcId")
+            if not subnet_id or not vpc_id:
+                continue
+
+            subnets.append(
+                {
+                    "subnet_id": subnet_id,
+                    "vpc_id": vpc_id,
+                    "availability_zone": subnet.get("AvailabilityZone", ""),
+                    "cidr_block": subnet.get("CidrBlock", ""),
+                    "available_ip_address_count": subnet.get(
+                        "AvailableIpAddressCount", 0
+                    ),
+                    "map_public_ip_on_launch": subnet.get(
+                        "MapPublicIpOnLaunch", False
+                    ),
+                }
+            )
+
+    return subnets, retry_attempts
+
+
+def run(
+    *,
+    account_id: str,
+    account_alias: str,
+    session,
+    dry_run: bool,
+    metadata: dict[str, object],
+    actions: ActionRecorder,
+) -> dict[str, object]:
+    """
+    Count subnets in the session's current AWS region and return timing data.
+    """
+    run_start = time.perf_counter()
+    region_name = session.region_name
+
+    client_start = time.perf_counter()
+    ec2_client = session.client("ec2")
+    client_seconds = _elapsed_seconds(client_start)
+
+    describe_subnets_start = time.perf_counter()
+    subnets, describe_subnets_retries = _get_subnet_details(ec2_client)
+    describe_subnets_seconds = _elapsed_seconds(describe_subnets_start)
+
+    vpc_ids = sorted(
+        {subnet["vpc_id"] for subnet in subnets if isinstance(subnet["vpc_id"], str)}
+    )
+    total_run_seconds = _elapsed_seconds(run_start)
+
+    timing = {
+        "client_seconds": client_seconds,
+        "describe_subnets_seconds": describe_subnets_seconds,
+        "total_run_seconds": total_run_seconds,
+        "describe_subnets_retries": describe_subnets_retries,
+    }
+
+    __LOGGER__.info(
+        f"Counted {len(subnets)} subnet(s) across {len(vpc_ids)} VPC(s) "
+        f"in account {account_alias} ({account_id}), "
+        f"region={region_name}, dry_run={dry_run}"
+    )
+    __LOGGER__.info(
+        f"Timing account={account_id} region={region_name}: "
+        f"client={client_seconds}s "
+        f"describe_subnets={describe_subnets_seconds}s "
+        f"retries={describe_subnets_retries} "
+        f"total={total_run_seconds}s"
+    )
+
+    actions.record(
+        f"Counted {len(subnets)} subnet(s) in account {account_id} "
+        f"region {region_name}"
+    )
+
+    return {
+        "summary": {
+            "total_subnets": len(subnets),
+            "total_vpcs": len(vpc_ids),
+        },
+        "subnets": subnets,
+        "timing": timing,
+    }

--- a/tests/cli/test_cli_parallel_targets.py
+++ b/tests/cli/test_cli_parallel_targets.py
@@ -12,7 +12,19 @@ def _import_cli_or_skip():
     return cli
 
 
-def test_run_single_config_file_passes_max_parallel_targets(monkeypatch):
+@pytest.mark.parametrize(
+    ("args", "expected_benchmark"),
+    [
+        (SimpleNamespace(dry_run=None, include=None, exclude=None), False),
+        (
+            SimpleNamespace(dry_run=None, include=None, exclude=None, benchmark=True),
+            True,
+        ),
+    ],
+)
+def test_run_single_config_file_passes_run_controls(
+    monkeypatch, args, expected_benchmark
+):
     from pathlib import Path
 
     cli = _import_cli_or_skip()
@@ -22,7 +34,6 @@ def test_run_single_config_file_passes_max_parallel_targets(monkeypatch):
         targets=["target-a"],
         max_parallel_targets=4,
     )
-    args = SimpleNamespace(dry_run=None, include=None, exclude=None)
     seen = {}
 
     monkeypatch.setattr(
@@ -41,3 +52,4 @@ def test_run_single_config_file_passes_max_parallel_targets(monkeypatch):
 
     assert exit_code == 0
     assert seen["kwargs"]["max_parallel_targets"] == 4
+    assert seen["kwargs"]["benchmark_enabled"] is expected_benchmark

--- a/tests/cli/test_cli_smoke.py
+++ b/tests/cli/test_cli_smoke.py
@@ -70,13 +70,18 @@ def test_cmd_run_returns_failure_if_any_config_file_fails(monkeypatch):
     assert seen_paths == [Path("orgs.yaml"), Path("orgs2.yaml"), Path("orgs3.yaml")]
 
 
-def test_write_run_results_prefixes_summary_with_config_stem(monkeypatch, tmp_path):
+def test_write_run_results_prefixes_summary_with_config_stem(monkeypatch):
     from pathlib import Path
     from types import SimpleNamespace
 
     cli = _import_cli_or_skip()
+    scratch_dir = (Path("tests") / "_tmp" / "cli-smoke").resolve()
+    results_dir = scratch_dir / "results"
+    summary_path = results_dir / "orgs-target-summary.json"
+    target_path = results_dir / "org2.json"
 
     engine_result = SimpleNamespace(
+        benchmark=None,
         target_results=[
             SimpleNamespace(target_name="org2", to_dict=lambda: {"name": "org2"})
         ],
@@ -84,14 +89,21 @@ def test_write_run_results_prefixes_summary_with_config_stem(monkeypatch, tmp_pa
     )
 
     original_cwd = Path.cwd()
-    monkeypatch.chdir(tmp_path)
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(scratch_dir)
 
     try:
         cli._write_run_results(
             config_file=Path("yaml/orgs.yaml"), engine_result=engine_result
         )
 
-        assert (tmp_path / "results" / "orgs-target-summary.json").exists()
-        assert (tmp_path / "results" / "org2.json").exists()
+        assert summary_path.exists()
+        assert target_path.exists()
     finally:
         monkeypatch.chdir(original_cwd)
+        summary_path.unlink(missing_ok=True)
+        target_path.unlink(missing_ok=True)
+        if results_dir.exists():
+            results_dir.rmdir()
+        if scratch_dir.exists():
+            scratch_dir.rmdir()

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 
@@ -7,11 +9,7 @@ def test_graph_fails_on_unknown_dependency(monkeypatch):
     except PermissionError as error:
         pytest.skip(f"jsonschema package resources unavailable in test env: {error}")
 
-    yaml_dir = pytest.Path("tests") if hasattr(pytest, "Path") else None
-    if yaml_dir is None:
-        from pathlib import Path
-
-        yaml_dir = Path("tests") / "_tmp"
+    yaml_dir = Path("tests") / "_tmp"
     yaml_dir.mkdir(exist_ok=True)
     yaml_file = yaml_dir / "graph-orgs.yaml"
 

--- a/tests/tasks/test_task_loader.py
+++ b/tests/tasks/test_task_loader.py
@@ -81,12 +81,3 @@ def test_discover_tasks_includes_stock_tasks():
     noop = next(task for task in tasks if task.name == "noop")
     assert noop.source == "stock"
     assert callable(noop.run)
-
-
-def test_stock_tasks_override_plugin_tasks(monkeypatch):
-    # monkeypatch entry_points() to return a conflicting plugin
-    ...
-    tasks = discover_tasks()
-
-    task = next(task for task in tasks if task.name == "noop")
-    assert task.source == "stock"

--- a/tests/tasks/test_task_loader_cache_integration.py
+++ b/tests/tasks/test_task_loader_cache_integration.py
@@ -71,7 +71,9 @@ def test_graph_and_run_paths_behave_the_same_with_cached_resolution(
         def resolve_accounts(self):
             return []
 
-    def fake_execute_accounts(*, name, config_branch, max_workers, context, accounts):
+    def fake_execute_accounts(
+        *, name, config_branch, max_workers, context, accounts, **kwargs
+    ):
         observed_tasks.append([task.name for task in context.tasks])
         return results.TargetResult.create(
             config_branch=config_branch,

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,31 @@
+from anvil.benchmark import BenchmarkRecorder
+
+
+def test_disabled_benchmark_recorder_is_noop():
+    recorder = BenchmarkRecorder(enabled=False)
+
+    with recorder.phase("phase_seconds"):
+        pass
+    recorder.set("value", 1)
+    recorder.update({"other": 2})
+
+    assert recorder.data is None
+    assert recorder.pop("phase_seconds") is None
+
+
+def test_enabled_benchmark_recorder_records_into_live_data():
+    data: dict[str, object] = {"existing": True}
+    recorder = BenchmarkRecorder(data=data)
+
+    with recorder.phase("phase_seconds"):
+        pass
+    recorder.set("value", 1)
+    recorder.update({"other": 2})
+
+    assert recorder.data is data
+    assert recorder.data["phase_seconds"] >= 0
+    assert recorder.data["value"] == 1
+    assert recorder.data["other"] == 2
+    assert recorder.data["existing"] is True
+    assert recorder.pop("value") == 1
+    assert "value" not in recorder.data


### PR DESCRIPTION
## Description
This adds benchmark timings for the major engine phases so benchmark output can
show where runtime is going during a run.

The new timings make it easier to separate:
- target preparation and task resolution
- organization preflight and discovery
- account execution
- result serialization and writing

The goal is to improve observability for optimization work without changing
execution behavior or task semantics.


## Checklist
- [x] Python format, lint, and tests (`ruff` and `pytest`) were successful.
- [x] Pre-commit hooks passed locally.
- [x] Documentation updated if needed.
- [x] Unit tests added or updated.
