### PR TITLE
Set explicit Dependabot commit message prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,7 @@ updates:
         patterns:
           - "*"
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: "chore(uv)"
     labels:
       - "dependencies"
       - "python"
@@ -40,8 +39,7 @@ updates:
         patterns:
           - "*"
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: "chore(github-actions)"
     labels:
       - "dependencies"
       - "github-actions"
@@ -61,8 +59,7 @@ updates:
         patterns:
           - "*"
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: "chore(pre-commit)"
     labels:
       - "dependencies"
       - "pre-commit"


### PR DESCRIPTION
Update .github/dependabot.yml to replace the previous generic commit-message config with explicit prefixes per update group.

## Description
Provide a clear and concise description of your changes.


## Checklist
- [ ] Python format, lint, and tests (`ruff` and `pytest`) were successful.
- [ ] Pre-commit hooks passed locally.
- [ ] Documentation updated if needed.
- [ ] Unit tests added or updated.
