### PR TITLE
Refactor/shared loader utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,7 +163,8 @@ cython_debug/
 .ruff_cache
 
 # anvil results
-./results/
+results/*
+!results/.gitkeep
 
 #macOS
 .DS_Store

--- a/src/anvil/_loader_utils.py
+++ b/src/anvil/_loader_utils.py
@@ -36,11 +36,7 @@ def _validate_run_callable(
 
 
 def load_stock_callable(
-    *,
-    name: str,
-    kind: str,
-    package_name: str,
-    error_type: type[RuntimeError],
+    *, name: str, kind: str, package_name: str, error_type: type[RuntimeError]
 ) -> Callable:
     """Load a named stock module and return its run callable."""
     module_name = f"{package_name}.{name}"
@@ -51,11 +47,7 @@ def load_stock_callable(
         raise error_type(f"Core {kind} '{name}' not found") from error
 
     return _validate_run_callable(
-        module=module,
-        name=name,
-        kind=kind,
-        source_label="Core",
-        error_type=error_type,
+        module=module, name=name, kind=kind, source_label="Core", error_type=error_type
     )
 
 
@@ -118,9 +110,7 @@ def load_plugin_callable(
 
 
 def iter_stock_modules(
-    *,
-    package_name: str,
-    load: Callable[[str], Callable],
+    *, package_name: str, load: Callable[[str], Callable]
 ) -> Iterable[DiscoveredModule]:
     """Yield public modules from a stock package without importing each module."""
     package = importlib.import_module(package_name)
@@ -130,9 +120,7 @@ def iter_stock_modules(
         if name.startswith("_"):
             continue
 
-        yield DiscoveredModule(
-            name=name, source="stock", load=lambda n=name: load(n)
-        )
+        yield DiscoveredModule(name=name, source="stock", load=lambda n=name: load(n))
 
 
 def plugin_source(entry_point: EntryPoint) -> str:

--- a/src/anvil/_loader_utils.py
+++ b/src/anvil/_loader_utils.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from importlib.metadata import EntryPoint, entry_points
+from types import ModuleType
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveredModule:
+    """Module discovered from a stock package or plugin package."""
+
+    name: str
+    source: str
+    load: Callable[[], Callable]
+
+
+def _validate_run_callable(
+    *,
+    module: ModuleType,
+    name: str,
+    kind: str,
+    source_label: str,
+    error_type: type[RuntimeError],
+) -> Callable:
+    run = getattr(module, "run", None)
+    if not callable(run):
+        raise error_type(
+            f"{source_label} {kind} '{name}' must define a callable run(...)"
+        )
+
+    return run
+
+
+def load_stock_callable(
+    *,
+    name: str,
+    kind: str,
+    package_name: str,
+    error_type: type[RuntimeError],
+) -> Callable:
+    """Load a named stock module and return its run callable."""
+    module_name = f"{package_name}.{name}"
+
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as error:
+        raise error_type(f"Core {kind} '{name}' not found") from error
+
+    return _validate_run_callable(
+        module=module,
+        name=name,
+        kind=kind,
+        source_label="Core",
+        error_type=error_type,
+    )
+
+
+def load_plugin_callable(
+    *,
+    name: str,
+    kind: str,
+    entry_point_group: str,
+    error_type: type[RuntimeError],
+    logger: logging.Logger,
+    import_failure_log_label: str,
+    import_issue_log_label: str,
+) -> Callable:
+    """Load a named plugin module from registered entry points."""
+    discovered_plugins: list[str] = []
+    import_failures: list[str] = []
+
+    for entry_point in entry_points(group=entry_point_group):
+        discovered_plugins.append(entry_point.name)
+
+        try:
+            pkg = importlib.import_module(entry_point.value)
+        except Exception as exc:
+            logger.debug(
+                f"Failed importing {import_failure_log_label} '{entry_point.value}' "
+                f"(entry point '{entry_point.name}'): {exc}"
+            )
+            import_failures.append(f"{entry_point.name}: package import failed ({exc})")
+            continue
+
+        try:
+            module = importlib.import_module(f"{pkg.__name__}.{name}")
+        except ModuleNotFoundError:
+            continue
+        except Exception as exc:
+            raise error_type(
+                f"Plugin {kind} '{name}' in plugin "
+                f"'{entry_point.name}' failed during import: {exc}"
+            ) from exc
+
+        run = getattr(module, "run", None)
+        if not callable(run):
+            raise error_type(
+                f"Plugin {kind} '{name}' in plugin "
+                f"'{entry_point.name}' must define callable run(...)"
+            )
+
+        return run
+
+    if import_failures:
+        logger.debug(
+            f"Plugin import issues encountered while resolving "
+            f"'{import_issue_log_label}': {import_failures}"
+        )
+
+    raise error_type(
+        f"Plugin {kind} '{name}' not found in registered entry points: "
+        f"{discovered_plugins}"
+    )
+
+
+def iter_stock_modules(
+    *,
+    package_name: str,
+    load: Callable[[str], Callable],
+) -> Iterable[DiscoveredModule]:
+    """Yield public modules from a stock package without importing each module."""
+    package = importlib.import_module(package_name)
+
+    for module_info in pkgutil.iter_modules(package.__path__):
+        name = module_info.name
+        if name.startswith("_"):
+            continue
+
+        yield DiscoveredModule(
+            name=name, source="stock", load=lambda n=name: load(n)
+        )
+
+
+def plugin_source(entry_point: EntryPoint) -> str:
+    """Return the display source for a plugin entry point."""
+    return (
+        f"plugin: {entry_point.dist.name}"
+        if entry_point.dist is not None
+        else "plugin (unpackaged)"
+    )
+
+
+def iter_plugin_modules(
+    *,
+    entry_point_group: str,
+    load: Callable[[str], Callable],
+    logger: logging.Logger,
+    skip_log_label: str,
+) -> Iterable[DiscoveredModule]:
+    """Yield public modules from plugin packages without importing each module."""
+    for entry_point in entry_points(group=entry_point_group):
+        try:
+            pkg = importlib.import_module(entry_point.value)
+        except Exception as exc:
+            logger.debug(
+                f"Skipping {skip_log_label} '{entry_point.name}' due to import error: "
+                f"{exc}"
+            )
+            continue
+
+        source = plugin_source(entry_point)
+        for module_info in pkgutil.iter_modules(pkg.__path__):
+            name = module_info.name
+            if name.startswith("_"):
+                continue
+
+            yield DiscoveredModule(
+                name=name, source=source, load=lambda n=name: load(n)
+            )

--- a/src/anvil/processor_loader.py
+++ b/src/anvil/processor_loader.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
-import importlib
 import json
 import logging
-import pkgutil
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from functools import lru_cache
-from importlib.metadata import entry_points
 from pathlib import Path
 
+from anvil._loader_utils import (
+    iter_plugin_modules,
+    iter_stock_modules,
+    load_plugin_callable,
+    load_stock_callable,
+)
 from anvil.descriptors import ConfigBranch, TargetDescriptor
 from anvil.results import TargetResult
 
@@ -239,74 +242,23 @@ def run_configured_post_processors(
 
 
 def _load_core_processor(processor_name: str) -> Callable:
-    module_name = f"anvil.processors.{processor_name}"
-
-    try:
-        module = importlib.import_module(module_name)
-    except ModuleNotFoundError as error:
-        raise ProcessorConfigError(
-            f"Core processor '{processor_name}' not found"
-        ) from error
-
-    run = getattr(module, "run", None)
-    if not callable(run):
-        raise ProcessorConfigError(
-            f"Core processor '{processor_name}' must define a callable run(...)"
-        )
-
-    return run
+    return load_stock_callable(
+        name=processor_name,
+        kind="processor",
+        package_name="anvil.processors",
+        error_type=ProcessorConfigError,
+    )
 
 
 def _load_plugin_processor(processor_name: str) -> Callable:
-    eps = entry_points(group=PROCESSOR_ENTRY_POINT_GROUP)
-
-    discovered_plugins: list[str] = []
-    import_failures: list[str] = []
-
-    for entry_point in eps:
-        discovered_plugins.append(entry_point.name)
-
-        # Import plugin package
-        try:
-            pkg = importlib.import_module(entry_point.value)
-        except Exception as exc:
-            __LOGGER__.debug(
-                f"Failed importing processor plugin package '{entry_point.value}' "
-                f"(entry point '{entry_point.name}'): {exc}"
-            )
-            import_failures.append(f"{entry_point.name}: package import failed ({exc})")
-            continue
-
-        # Try loading processor module inside plugin
-        try:
-            module = importlib.import_module(f"{pkg.__name__}.{processor_name}")
-        except ModuleNotFoundError:
-            # Plugin simply doesn't provide this processor
-            continue
-        except Exception as exc:
-            raise ProcessorConfigError(
-                f"Plugin processor '{processor_name}' in plugin "
-                f"'{entry_point.name}' failed during import: {exc}"
-            ) from exc
-
-        run = getattr(module, "run", None)
-        if not callable(run):
-            raise ProcessorConfigError(
-                f"Plugin processor '{processor_name}' in plugin "
-                f"'{entry_point.name}' must define callable run(...)"
-            )
-
-        return run
-
-    if import_failures:
-        __LOGGER__.debug(
-            f"Plugin import issues encountered while resolving '{processor_name}': "
-            f"{import_failures}"
-        )
-
-    raise ProcessorConfigError(
-        f"Plugin processor '{processor_name}' not found in registered entry points: "
-        f"{discovered_plugins}"
+    return load_plugin_callable(
+        name=processor_name,
+        kind="processor",
+        entry_point_group=PROCESSOR_ENTRY_POINT_GROUP,
+        error_type=ProcessorConfigError,
+        logger=__LOGGER__,
+        import_failure_log_label="processor plugin package",
+        import_issue_log_label=processor_name,
     )
 
 
@@ -328,48 +280,28 @@ def discover_processors() -> list[ProcessorDescriptor]:
     """Discover stock and plugin processors without executing them."""
     processors: list[ProcessorDescriptor] = []
 
-    # Core processors
-    import anvil.processors
-
-    for module_info in pkgutil.iter_modules(anvil.processors.__path__):
-        name = module_info.name
-        if name.startswith("_"):
-            continue
-
+    for module in iter_stock_modules(
+        package_name="anvil.processors", load=_load_core_processor
+    ):
         processors.append(
             ProcessorDescriptor(
-                name=name, run=lambda n=name: _load_core_processor(n), source="stock"
+                name=module.name, run=module.load, source=module.source
             )
         )
 
-    # Plugin processors (package scan, no imports)
-    for entry_point in entry_points(group=PROCESSOR_ENTRY_POINT_GROUP):
-        try:
-            pkg = importlib.import_module(entry_point.value)
-        except Exception as exc:
-            __LOGGER__.debug(
-                f"Skipping processor plugin '{entry_point.name}' due to import error: "
-                f"{exc}"
+    for module in iter_plugin_modules(
+        entry_point_group=PROCESSOR_ENTRY_POINT_GROUP,
+        load=_load_plugin_processor,
+        logger=__LOGGER__,
+        skip_log_label="processor plugin",
+    ):
+        processors.append(
+            ProcessorDescriptor(
+                name=module.name,
+                run=module.load,
+                source=module.source,
             )
-            continue
-
-        for module_info in pkgutil.iter_modules(pkg.__path__):
-            name = module_info.name
-            if name.startswith("_"):
-                continue
-
-            source = (
-                f"plugin: {entry_point.dist.name}"
-                if entry_point.dist is not None
-                else "plugin (unpackaged)"
-            )
-            processors.append(
-                ProcessorDescriptor(
-                    name=name,
-                    run=lambda n=name: _load_plugin_processor(n),
-                    source=source,
-                )
-            )
+        )
 
     return processors
 

--- a/src/anvil/processor_loader.py
+++ b/src/anvil/processor_loader.py
@@ -284,9 +284,7 @@ def discover_processors() -> list[ProcessorDescriptor]:
         package_name="anvil.processors", load=_load_core_processor
     ):
         processors.append(
-            ProcessorDescriptor(
-                name=module.name, run=module.load, source=module.source
-            )
+            ProcessorDescriptor(name=module.name, run=module.load, source=module.source)
         )
 
     for module in iter_plugin_modules(
@@ -296,11 +294,7 @@ def discover_processors() -> list[ProcessorDescriptor]:
         skip_log_label="processor plugin",
     ):
         processors.append(
-            ProcessorDescriptor(
-                name=module.name,
-                run=module.load,
-                source=module.source,
-            )
+            ProcessorDescriptor(name=module.name, run=module.load, source=module.source)
         )
 
     return processors

--- a/src/anvil/task_loader.py
+++ b/src/anvil/task_loader.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-import importlib
 import logging
-import pkgutil
 from collections import defaultdict, deque
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
-from importlib.metadata import entry_points
+
+from anvil._loader_utils import (
+    iter_plugin_modules,
+    iter_stock_modules,
+    load_plugin_callable,
+    load_stock_callable,
+)
 
 __LOGGER__ = logging.getLogger(__name__)
 
@@ -60,72 +64,23 @@ class ResolvedExecution:
 
 
 def _load_core_task(task_name: str) -> Callable:
-    module_name = f"anvil.tasks.{task_name}"
-
-    try:
-        module = importlib.import_module(module_name)
-    except ModuleNotFoundError:
-        raise TaskConfigError(f"Core task '{task_name}' not found")
-
-    run = getattr(module, "run", None)
-    if not callable(run):
-        raise TaskConfigError(
-            f"Core task '{task_name}' must define a callable run(...)"
-        )
-
-    return run
+    return load_stock_callable(
+        name=task_name,
+        kind="task",
+        package_name="anvil.tasks",
+        error_type=TaskConfigError,
+    )
 
 
 def _load_plugin_task(task_name: str) -> Callable:
-    eps = entry_points(group=TASK_ENTRY_POINT_GROUP)
-
-    discovered_plugins: list[str] = []
-    import_failures: list[str] = []
-
-    for entry_point in eps:
-        discovered_plugins.append(entry_point.name)
-
-        # Import plugin package
-        try:
-            pkg = importlib.import_module(entry_point.value)
-        except Exception as exc:
-            __LOGGER__.debug(
-                f"Failed importing plugin package '{entry_point.value}' "
-                f"(entry point '{entry_point.name}'): {exc}"
-            )
-            import_failures.append(f"{entry_point.name}: package import failed ({exc})")
-            continue
-
-        # Try loading task module inside plugin
-        try:
-            module = importlib.import_module(f"{pkg.__name__}.{task_name}")
-        except ModuleNotFoundError:
-            # Plugin simply doesn't provide this task
-            continue
-        except Exception as exc:
-            raise TaskConfigError(
-                f"Plugin task '{task_name}' in plugin "
-                f"'{entry_point.name}' failed during import: {exc}"
-            ) from exc
-
-        run = getattr(module, "run", None)
-        if not callable(run):
-            raise TaskConfigError(
-                f"Plugin task '{task_name}' in plugin "
-                f"'{entry_point.name}' must define callable run(...)"
-            )
-
-        return run
-
-    if import_failures:
-        __LOGGER__.debug(
-            f"Plugin import issues encountered while resolving '{task_name}': "
-            f"{import_failures}"
-        )
-
-    raise TaskConfigError(
-        f"Plugin task '{task_name}' not found in registered entry points: "
-        f"{discovered_plugins}"
+    return load_plugin_callable(
+        name=task_name,
+        kind="task",
+        entry_point_group=TASK_ENTRY_POINT_GROUP,
+        error_type=TaskConfigError,
+        logger=__LOGGER__,
+        import_failure_log_label="plugin package",
+        import_issue_log_label=task_name,
     )
 
 
@@ -299,42 +254,24 @@ def resolve_tasks(*, task_specs: Sequence[TaskSpecInput]) -> ResolvedExecution:
 def discover_tasks() -> list[TaskDescriptor]:
     tasks: dict[str, TaskDescriptor] = {}
 
-    # Core tasks
-    import anvil.tasks
-
-    for module_info in pkgutil.iter_modules(anvil.tasks.__path__):
-        name = module_info.name
-        if name.startswith("_"):
-            continue
-
+    for module in iter_stock_modules(package_name="anvil.tasks", load=_load_core_task):
+        name = module.name
         tasks[name] = TaskDescriptor(
-            name=name, run=lambda n=name: _load_core_task(n), source="stock"
+            name=name, run=module.load, source=module.source
         )
 
-    # Plugin tasks (package scan, no imports)
-    for entry_point in entry_points(group=TASK_ENTRY_POINT_GROUP):
-        try:
-            pkg = importlib.import_module(entry_point.value)
-        except Exception as exc:
-            __LOGGER__.debug(
-                f"Skipping plugin '{entry_point.name}' due to import error: {exc}"
-            )
+    for module in iter_plugin_modules(
+        entry_point_group=TASK_ENTRY_POINT_GROUP,
+        load=_load_plugin_task,
+        logger=__LOGGER__,
+        skip_log_label="plugin",
+    ):
+        if module.name in tasks:
             continue
 
-        for module_info in pkgutil.iter_modules(pkg.__path__):
-            name = module_info.name
-            if name.startswith("_") or name in tasks:
-                continue
-
-            source = (
-                f"plugin: {entry_point.dist.name}"
-                if entry_point.dist is not None
-                else "plugin (unpackaged)"
-            )
-
-            tasks[name] = TaskDescriptor(
-                name=name, run=lambda n=name: _load_plugin_task(n), source=source
-            )
+        tasks[module.name] = TaskDescriptor(
+            name=module.name, run=module.load, source=module.source
+        )
 
     return list(tasks.values())
 

--- a/src/anvil/task_loader.py
+++ b/src/anvil/task_loader.py
@@ -256,9 +256,7 @@ def discover_tasks() -> list[TaskDescriptor]:
 
     for module in iter_stock_modules(package_name="anvil.tasks", load=_load_core_task):
         name = module.name
-        tasks[name] = TaskDescriptor(
-            name=name, run=module.load, source=module.source
-        )
+        tasks[name] = TaskDescriptor(name=name, run=module.load, source=module.source)
 
     for module in iter_plugin_modules(
         entry_point_group=TASK_ENTRY_POINT_GROUP,

--- a/tests/test_loader_plugin_entry_points.py
+++ b/tests/test_loader_plugin_entry_points.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from anvil import processor_loader, task_loader
+
+
+def _write_plugin_distribution(
+    *,
+    root: Path,
+    distribution_name: str,
+    package_name: str,
+    entry_point_group: str,
+    entry_point_name: str,
+    module_name: str,
+    module_body: str,
+) -> None:
+    package_dir = root / package_name
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    (package_dir / f"{module_name}.py").write_text(module_body, encoding="utf-8")
+
+    dist_info_dir = root / f"{distribution_name.replace('-', '_')}-1.0.dist-info"
+    dist_info_dir.mkdir()
+    (dist_info_dir / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {distribution_name}\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (dist_info_dir / "entry_points.txt").write_text(
+        f"[{entry_point_group}]\n{entry_point_name} = {package_name}\n",
+        encoding="utf-8",
+    )
+
+
+def test_resolve_tasks_loads_real_plugin_entry_point(monkeypatch, tmp_path):
+    _write_plugin_distribution(
+        root=tmp_path,
+        distribution_name="anvil-test-task-plugin",
+        package_name="anvil_test_task_plugin",
+        entry_point_group=task_loader.TASK_ENTRY_POINT_GROUP,
+        entry_point_name="test-task-plugin",
+        module_name="real_plugin_task",
+        module_body='def run(**kwargs):\n    return {"source": "plugin-task"}\n',
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+    task_loader._load_task_callable.cache_clear()
+    task_loader._resolve_tasks_cached.cache_clear()
+
+    execution = task_loader.resolve_tasks(task_specs=[{"name": "real_plugin_task"}])
+
+    assert execution.ordered[0].name == "real_plugin_task"
+    assert execution.ordered[0].run() == {"source": "plugin-task"}
+
+
+def test_discover_tasks_includes_real_plugin_entry_point(monkeypatch, tmp_path):
+    _write_plugin_distribution(
+        root=tmp_path,
+        distribution_name="anvil-test-task-discovery-plugin",
+        package_name="anvil_test_task_discovery_plugin",
+        entry_point_group=task_loader.TASK_ENTRY_POINT_GROUP,
+        entry_point_name="test-task-discovery-plugin",
+        module_name="discoverable_plugin_task",
+        module_body='def run(**kwargs):\n    return {"source": "plugin-task"}\n',
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+
+    descriptors = task_loader.discover_tasks()
+    descriptor = next(
+        task for task in descriptors if task.name == "discoverable_plugin_task"
+    )
+
+    assert descriptor.source == "plugin: anvil-test-task-discovery-plugin"
+    assert descriptor.run()() == {"source": "plugin-task"}
+
+
+def test_discover_processors_includes_real_plugin_entry_point(monkeypatch, tmp_path):
+    _write_plugin_distribution(
+        root=tmp_path,
+        distribution_name="anvil-test-processor-plugin",
+        package_name="anvil_test_processor_plugin",
+        entry_point_group=processor_loader.PROCESSOR_ENTRY_POINT_GROUP,
+        entry_point_name="test-processor-plugin",
+        module_name="real_plugin_processor",
+        module_body=(
+            "def run(*, context, output, metadata):\n"
+            '    return {"output": output, "metadata": metadata}\n'
+        ),
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+    processor_loader.load_processor_callable.cache_clear()
+
+    descriptors = processor_loader.discover_processors()
+    descriptor = next(
+        processor
+        for processor in descriptors
+        if processor.name == "real_plugin_processor"
+    )
+
+    assert descriptor.source == "plugin: anvil-test-processor-plugin"
+    assert descriptor.run()(context=None, output="report.md", metadata={"ok": True}) == {
+        "output": "report.md",
+        "metadata": {"ok": True},
+    }

--- a/tests/test_loader_plugin_entry_points.py
+++ b/tests/test_loader_plugin_entry_points.py
@@ -101,7 +101,6 @@ def test_discover_processors_includes_real_plugin_entry_point(monkeypatch, tmp_p
     )
 
     assert descriptor.source == "plugin: anvil-test-processor-plugin"
-    assert descriptor.run()(context=None, output="report.md", metadata={"ok": True}) == {
-        "output": "report.md",
-        "metadata": {"ok": True},
-    }
+    assert descriptor.run()(
+        context=None, output="report.md", metadata={"ok": True}
+    ) == {"output": "report.md", "metadata": {"ok": True}}


### PR DESCRIPTION
Refactors shared task and processor loader mechanics into a private internal helper.

Adds anvil._loader_utils for stock/plugin callable loading and module discovery
Keeps task and processor cache boundaries unchanged in their existing loader modules
Preserves task-specific plugin dedupe behavior and processor duplicate discovery behavior
Adds real plugin entry-point tests using temporary packages and .dist-info/entry_points.txt


## Checklist
- [x] Python format, lint, and tests (`ruff` and `pytest`) were successful.
- [x] Pre-commit hooks passed locally.
- [ ] Documentation updated if needed.
- [x] Unit tests added or updated.
