### PR TITLE
Fix/loadables

### DIFF
--- a/src/anvil/_loader_utils.py
+++ b/src/anvil/_loader_utils.py
@@ -18,6 +18,23 @@ class DiscoveredModule:
     load: Callable[[], Callable]
 
 
+@dataclass(frozen=True, slots=True)
+class DiscoveryIssue:
+    """Problem encountered while discovering plugin modules."""
+
+    name: str
+    source: str
+    error: str
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleDiscoveryResult:
+    """Discovered modules and non-fatal discovery issues."""
+
+    modules: list[DiscoveredModule]
+    issues: list[DiscoveryIssue]
+
+
 def _validate_run_callable(
     *,
     module: ModuleType,
@@ -132,14 +149,17 @@ def plugin_source(entry_point: EntryPoint) -> str:
     )
 
 
-def iter_plugin_modules(
+def discover_plugin_modules(
     *,
     entry_point_group: str,
     load: Callable[[str], Callable],
     logger: logging.Logger,
     skip_log_label: str,
-) -> Iterable[DiscoveredModule]:
-    """Yield public modules from plugin packages without importing each module."""
+) -> ModuleDiscoveryResult:
+    """Discover plugin modules and capture packages that cannot be imported."""
+    modules: list[DiscoveredModule] = []
+    issues: list[DiscoveryIssue] = []
+
     for entry_point in entry_points(group=entry_point_group):
         try:
             pkg = importlib.import_module(entry_point.value)
@@ -147,6 +167,13 @@ def iter_plugin_modules(
             logger.debug(
                 f"Skipping {skip_log_label} '{entry_point.name}' due to import error: "
                 f"{exc}"
+            )
+            issues.append(
+                DiscoveryIssue(
+                    name=entry_point.name,
+                    source=plugin_source(entry_point),
+                    error=f"package import failed ({exc})",
+                )
             )
             continue
 
@@ -156,6 +183,8 @@ def iter_plugin_modules(
             if name.startswith("_"):
                 continue
 
-            yield DiscoveredModule(
-                name=name, source=source, load=lambda n=name: load(n)
+            modules.append(
+                DiscoveredModule(name=name, source=source, load=lambda n=name: load(n))
             )
+
+    return ModuleDiscoveryResult(modules=modules, issues=issues)

--- a/src/anvil/_loader_utils.py
+++ b/src/anvil/_loader_utils.py
@@ -95,10 +95,16 @@ def load_plugin_callable(
             import_failures.append(f"{entry_point.name}: package import failed ({exc})")
             continue
 
+        module_name = f"{pkg.__name__}.{name}"
         try:
-            module = importlib.import_module(f"{pkg.__name__}.{name}")
-        except ModuleNotFoundError:
-            continue
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            if exc.name == module_name:
+                continue
+            raise error_type(
+                f"Plugin {kind} '{name}' in plugin "
+                f"'{entry_point.name}' failed during import: {exc}"
+            ) from exc
         except Exception as exc:
             raise error_type(
                 f"Plugin {kind} '{name}' in plugin "

--- a/src/anvil/cli.py
+++ b/src/anvil/cli.py
@@ -30,7 +30,7 @@ from anvil.processor_loader import (
     run_configured_post_processors,
     run_processors,
 )
-from anvil.processor_validation import validate_processors
+from anvil.processor_validation import processor_validation_errors
 from anvil.result_query import (
     ResultFilters,
     build_rerun_targets,
@@ -49,7 +49,7 @@ from anvil.result_query import (
 from anvil.results import EngineResult, EngineState
 from anvil.runner import run_auth_checks, run_multiple_targets
 from anvil.task_loader import ResolvedTask, TaskDescriptor, discover_tasks, list_tasks
-from anvil.task_validation import validate_tasks
+from anvil.task_validation import task_validation_errors
 from anvil.validators import load_config_descriptors, validate_config_schema
 
 __LOGGER__ = logging.getLogger(__name__)
@@ -389,18 +389,6 @@ def _discovery_issue_messages(issues: list[DiscoveryIssue]) -> list[str]:
     return [f"{issue.name} ({issue.source}): {issue.error}" for issue in issues]
 
 
-def _validation_error_messages(error: Exception) -> list[str]:
-    messages: list[str] = []
-    for line in str(error).splitlines():
-        message = line.strip()
-        if not message:
-            continue
-        if message.startswith("- "):
-            message = message[2:].strip()
-        messages.append(message)
-    return messages
-
-
 def _raise_validation_errors(errors: list[str]) -> None:
     if errors:
         raise ValueError("\n  - " + "\n  - ".join(errors))
@@ -439,7 +427,7 @@ def _validate_selected_tasks(task_names: list[str] | None) -> None:
                 descriptors=discovery.tasks, task_names=task_names
             )
         except ValueError as exc:
-            errors.extend(_validation_error_messages(exc))
+            errors.append(str(exc))
             errors.extend(_discovery_issue_messages(discovery.issues))
             _raise_validation_errors(errors)
     else:
@@ -457,11 +445,7 @@ def _validate_selected_tasks(task_names: list[str] | None) -> None:
             ResolvedTask(name=descriptor.name, run=run, depends_on=[], optional=False)
         )
 
-    try:
-        validate_tasks(resolved)
-    except Exception as exc:
-        errors.extend(_validation_error_messages(exc))
-
+    errors.extend(task_validation_errors(resolved))
     _raise_validation_errors(errors)
 
 
@@ -502,17 +486,13 @@ def _validate_selected_processors(processor_names: list[str] | None) -> None:
                 descriptors=discovery.processors, processor_names=processor_names
             )
         except ValueError as exc:
-            errors.extend(_validation_error_messages(exc))
+            errors.append(str(exc))
             errors.extend(_discovery_issue_messages(discovery.issues))
             _raise_validation_errors(errors)
     else:
         errors.extend(_discovery_issue_messages(discovery.issues))
 
-    try:
-        validate_processors(processors)
-    except Exception as exc:
-        errors.extend(_validation_error_messages(exc))
-
+    errors.extend(processor_validation_errors(processors))
     _raise_validation_errors(errors)
 
 

--- a/src/anvil/cli.py
+++ b/src/anvil/cli.py
@@ -13,10 +13,13 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
-from anvil.graph import render_graph
+
 import yaml
+
+from anvil._loader_utils import DiscoveryIssue
 from anvil.benchmark import BenchmarkRecorder
 from anvil.descriptors import ConfigBranch, LoadedConfig
+from anvil.graph import render_graph
 from anvil.processor_loader import (
     ProcessorDescriptor,
     ProcessorSpec,
@@ -45,13 +48,7 @@ from anvil.result_query import (
 )
 from anvil.results import EngineResult, EngineState
 from anvil.runner import run_auth_checks, run_multiple_targets
-from anvil.task_loader import (
-    ResolvedTask,
-    TaskDescriptor,
-    _load_task_callable,
-    discover_tasks,
-    list_tasks,
-)
+from anvil.task_loader import ResolvedTask, TaskDescriptor, discover_tasks, list_tasks
 from anvil.task_validation import validate_tasks
 from anvil.validators import load_config_descriptors, validate_config_schema
 
@@ -388,8 +385,30 @@ def _cmd_list(args: argparse.Namespace) -> int:
     return 0
 
 
-def _select_tasks(task_names: list[str]) -> list[TaskDescriptor]:
-    descriptors: list[TaskDescriptor] = discover_tasks()
+def _discovery_issue_messages(issues: list[DiscoveryIssue]) -> list[str]:
+    return [f"{issue.name} ({issue.source}): {issue.error}" for issue in issues]
+
+
+def _validation_error_messages(error: Exception) -> list[str]:
+    messages: list[str] = []
+    for line in str(error).splitlines():
+        message = line.strip()
+        if not message:
+            continue
+        if message.startswith("- "):
+            message = message[2:].strip()
+        messages.append(message)
+    return messages
+
+
+def _raise_validation_errors(errors: list[str]) -> None:
+    if errors:
+        raise ValueError("\n  - " + "\n  - ".join(errors))
+
+
+def _select_task_descriptors(
+    *, descriptors: list[TaskDescriptor], task_names: list[str]
+) -> list[TaskDescriptor]:
     descriptor_by_name = {descriptor.name: descriptor for descriptor in descriptors}
     unknown_names = [name for name in task_names if name not in descriptor_by_name]
 
@@ -403,20 +422,52 @@ def _select_tasks(task_names: list[str]) -> list[TaskDescriptor]:
     return [descriptor_by_name[name] for name in task_names]
 
 
+def _select_tasks(task_names: list[str]) -> list[TaskDescriptor]:
+    return _select_task_descriptors(
+        descriptors=discover_tasks().tasks, task_names=task_names
+    )
+
+
 def _validate_selected_tasks(task_names: list[str] | None) -> None:
-    descriptors = discover_tasks() if not task_names else _select_tasks(task_names)
+    discovery = discover_tasks()
+    errors: list[str] = []
+    descriptors = discovery.tasks
+
+    if task_names:
+        try:
+            descriptors = _select_task_descriptors(
+                descriptors=discovery.tasks, task_names=task_names
+            )
+        except ValueError as exc:
+            errors.extend(_validation_error_messages(exc))
+            errors.extend(_discovery_issue_messages(discovery.issues))
+            _raise_validation_errors(errors)
+    else:
+        errors.extend(_discovery_issue_messages(discovery.issues))
+
     resolved = []
     for descriptor in descriptors:
-        run = _load_task_callable(descriptor.name)
+        try:
+            run = descriptor.load()
+        except Exception as exc:
+            errors.append(f"{descriptor.name} ({descriptor.source}): {exc}")
+            continue
+
         resolved.append(
             ResolvedTask(name=descriptor.name, run=run, depends_on=[], optional=False)
         )
 
-    validate_tasks(resolved)
+    try:
+        validate_tasks(resolved)
+    except Exception as exc:
+        errors.extend(_validation_error_messages(exc))
+
+    _raise_validation_errors(errors)
 
 
-def _select_processors(processor_names: list[str]) -> list[ProcessorDescriptor]:
-    descriptors = discover_processors()
+def _select_processor_descriptors(
+    *, descriptors: list[ProcessorDescriptor], processor_names: list[str]
+) -> list[ProcessorDescriptor]:
     requested_names = set(processor_names)
     available_names = {descriptor.name for descriptor in descriptors}
     unknown_names = [name for name in processor_names if name not in available_names]
@@ -434,13 +485,35 @@ def _select_processors(processor_names: list[str]) -> list[ProcessorDescriptor]:
     ]
 
 
-def _validate_selected_processors(processor_names: list[str] | None) -> None:
-    processors = (
-        discover_processors()
-        if not processor_names
-        else _select_processors(processor_names)
+def _select_processors(processor_names: list[str]) -> list[ProcessorDescriptor]:
+    return _select_processor_descriptors(
+        descriptors=discover_processors().processors, processor_names=processor_names
     )
-    validate_processors(processors)
+
+
+def _validate_selected_processors(processor_names: list[str] | None) -> None:
+    discovery = discover_processors()
+    errors: list[str] = []
+    processors = discovery.processors
+
+    if processor_names:
+        try:
+            processors = _select_processor_descriptors(
+                descriptors=discovery.processors, processor_names=processor_names
+            )
+        except ValueError as exc:
+            errors.extend(_validation_error_messages(exc))
+            errors.extend(_discovery_issue_messages(discovery.issues))
+            _raise_validation_errors(errors)
+    else:
+        errors.extend(_discovery_issue_messages(discovery.issues))
+
+    try:
+        validate_processors(processors)
+    except Exception as exc:
+        errors.extend(_validation_error_messages(exc))
+
+    _raise_validation_errors(errors)
 
 
 def _validation_result(label: str, callback) -> ValidationResult:
@@ -463,11 +536,6 @@ def _print_validation_summary(results: list[ValidationResult]) -> None:
             for error_line in result.error.splitlines():
                 if error_line:
                     print(f"         {error_line}")
-
-    print()
-    print(
-        f"Result: {'Success' if all(result.succeeded for result in results) else 'Failed'}"
-    )
 
 
 def _cmd_validate(args: argparse.Namespace) -> int:

--- a/src/anvil/processor_loader.py
+++ b/src/anvil/processor_loader.py
@@ -8,7 +8,8 @@ from functools import lru_cache
 from pathlib import Path
 
 from anvil._loader_utils import (
-    iter_plugin_modules,
+    DiscoveryIssue,
+    discover_plugin_modules,
     iter_stock_modules,
     load_plugin_callable,
     load_stock_callable,
@@ -40,11 +41,19 @@ class ProcessorSpec:
 
 @dataclass(frozen=True, slots=True)
 class ProcessorDescriptor:
-    """Discovered processor and its source package."""
+    """Discovered processor and lazy loader for its run callable."""
 
     name: str
-    run: Callable
+    load: Callable[[], Callable]
     source: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessorDiscoveryResult:
+    """Discovered processors and non-fatal discovery issues."""
+
+    processors: list[ProcessorDescriptor]
+    issues: list[DiscoveryIssue]
 
 
 @dataclass(frozen=True, slots=True)
@@ -276,34 +285,40 @@ def load_processor_callable(processor_name: str) -> Callable:
         return _load_plugin_processor(processor_name)
 
 
-def discover_processors() -> list[ProcessorDescriptor]:
-    """Discover stock and plugin processors without executing them."""
+def discover_processors() -> ProcessorDiscoveryResult:
+    """Discover processors and report plugin packages that cannot be inspected."""
     processors: list[ProcessorDescriptor] = []
 
     for module in iter_stock_modules(
         package_name="anvil.processors", load=_load_core_processor
     ):
         processors.append(
-            ProcessorDescriptor(name=module.name, run=module.load, source=module.source)
+            ProcessorDescriptor(
+                name=module.name, load=module.load, source=module.source
+            )
         )
 
-    for module in iter_plugin_modules(
+    plugin_result = discover_plugin_modules(
         entry_point_group=PROCESSOR_ENTRY_POINT_GROUP,
         load=_load_plugin_processor,
         logger=__LOGGER__,
         skip_log_label="processor plugin",
-    ):
+    )
+    for module in plugin_result.modules:
         processors.append(
-            ProcessorDescriptor(name=module.name, run=module.load, source=module.source)
+            ProcessorDescriptor(
+                name=module.name, load=module.load, source=module.source
+            )
         )
 
-    return processors
+    return ProcessorDiscoveryResult(processors=processors, issues=plugin_result.issues)
 
 
 def list_processors() -> list[ProcessorDescriptor]:
     """Return processors sorted by source and name."""
     return sorted(
-        discover_processors(), key=lambda processor: (processor.source, processor.name)
+        discover_processors().processors,
+        key=lambda processor: (processor.source, processor.name),
     )
 
 

--- a/src/anvil/processor_validation.py
+++ b/src/anvil/processor_validation.py
@@ -22,6 +22,13 @@ class ProcessorValidationError(ValueError):
 
 def validate_processors(processors: list[ProcessorDescriptor]) -> None:
     """Validate discovered processors without executing them."""
+    errors = processor_validation_errors(processors)
+    if errors:
+        raise ProcessorValidationError("\n  - " + "\n  - ".join(errors))
+
+
+def processor_validation_errors(processors: list[ProcessorDescriptor]) -> list[str]:
+    """Return structural validation errors for processor definitions."""
     errors: list[str] = []
     seen_names: set[str] = set()
 
@@ -55,8 +62,7 @@ def validate_processors(processors: list[ProcessorDescriptor]) -> None:
         except Exception as exc:
             errors.append(f"{processor.name} ({processor.source}): {exc}")
 
-    if errors:
-        raise ProcessorValidationError("\n  - " + "\n  - ".join(errors))
+    return errors
 
 
 def _validate_processor_run_signature(*, name: str, run: Callable) -> None:

--- a/src/anvil/processor_validation.py
+++ b/src/anvil/processor_validation.py
@@ -2,7 +2,8 @@
 Processor validation for Anvil.
 
 This module performs structural validation of post-run processor definitions.
-It does not execute processors against result data.
+It loads processor modules to inspect run(...) signatures, but does not execute
+processors against result data.
 """
 
 from __future__ import annotations
@@ -20,7 +21,7 @@ class ProcessorValidationError(ValueError):
 
 
 def validate_processors(processors: list[ProcessorDescriptor]) -> None:
-    """Validate discovered processors without running them."""
+    """Validate discovered processors without executing them."""
     errors: list[str] = []
     seen_names: set[str] = set()
 
@@ -38,12 +39,12 @@ def validate_processors(processors: list[ProcessorDescriptor]) -> None:
 
             seen_names.add(processor.name)
 
-            if not callable(processor.run):
+            if not callable(processor.load):
                 raise ProcessorValidationError(
-                    f"processor '{processor.name}'.run is not callable"
+                    f"processor '{processor.name}'.load is not callable"
                 )
 
-            run = processor.run()
+            run = processor.load()
             if not callable(run):
                 raise ProcessorValidationError(
                     f"processor '{processor.name}' is missing required run() function"

--- a/src/anvil/task_loader.py
+++ b/src/anvil/task_loader.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from functools import lru_cache
 
 from anvil._loader_utils import (
-    iter_plugin_modules,
+    DiscoveryIssue,
+    discover_plugin_modules,
     iter_stock_modules,
     load_plugin_callable,
     load_stock_callable,
@@ -47,9 +48,19 @@ class TaskConfigError(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class TaskDescriptor:
+    """Discovered task and lazy loader for its run callable."""
+
     name: str
-    run: Callable
+    load: Callable[[], Callable]
     source: str
+
+
+@dataclass(frozen=True, slots=True)
+class TaskDiscoveryResult:
+    """Discovered tasks and non-fatal discovery issues."""
+
+    tasks: list[TaskDescriptor]
+    issues: list[DiscoveryIssue]
 
 
 @dataclass(frozen=True, slots=True)
@@ -251,28 +262,30 @@ def resolve_tasks(*, task_specs: Sequence[TaskSpecInput]) -> ResolvedExecution:
     return _build_resolved_execution(ordered, adjacency)
 
 
-def discover_tasks() -> list[TaskDescriptor]:
+def discover_tasks() -> TaskDiscoveryResult:
+    """Discover tasks and report plugin packages that cannot be inspected."""
     tasks: dict[str, TaskDescriptor] = {}
 
     for module in iter_stock_modules(package_name="anvil.tasks", load=_load_core_task):
         name = module.name
-        tasks[name] = TaskDescriptor(name=name, run=module.load, source=module.source)
+        tasks[name] = TaskDescriptor(name=name, load=module.load, source=module.source)
 
-    for module in iter_plugin_modules(
+    plugin_result = discover_plugin_modules(
         entry_point_group=TASK_ENTRY_POINT_GROUP,
         load=_load_plugin_task,
         logger=__LOGGER__,
         skip_log_label="plugin",
-    ):
+    )
+    for module in plugin_result.modules:
         if module.name in tasks:
             continue
 
         tasks[module.name] = TaskDescriptor(
-            name=module.name, run=module.load, source=module.source
+            name=module.name, load=module.load, source=module.source
         )
 
-    return list(tasks.values())
+    return TaskDiscoveryResult(tasks=list(tasks.values()), issues=plugin_result.issues)
 
 
 def list_tasks() -> list[TaskDescriptor]:
-    return sorted(discover_tasks(), key=lambda task: (task.source, task.name))
+    return sorted(discover_tasks().tasks, key=lambda task: (task.source, task.name))

--- a/src/anvil/task_validation.py
+++ b/src/anvil/task_validation.py
@@ -25,6 +25,13 @@ class TaskValidationError(ValueError):
 
 
 def validate_tasks(tasks: list) -> None:
+    errors = task_validation_errors(tasks)
+    if errors:
+        raise TaskValidationError("\n  - " + "\n  - ".join(errors))
+
+
+def task_validation_errors(tasks: list) -> list[str]:
+    """Return structural validation errors for task definitions."""
     errors: list[str] = []
     seen_names: set[str] = set()
 
@@ -49,8 +56,7 @@ def validate_tasks(tasks: list) -> None:
         except TaskValidationError as exc:
             errors.append(str(exc))
 
-    if errors:
-        raise TaskValidationError("\n  - " + "\n  - ".join(errors))
+    return errors
 
 
 def _validate_task_run_signature(task) -> None:

--- a/tests/cli/test_list_command.py
+++ b/tests/cli/test_list_command.py
@@ -96,10 +96,10 @@ def test_cmd_list_tasks_groups_by_source(monkeypatch, capsys):
         cli,
         "list_tasks",
         lambda: [
-            cli.TaskDescriptor(name="count_vpc", run=lambda: None, source="stock"),
-            cli.TaskDescriptor(name="noop", run=lambda: None, source="stock"),
+            cli.TaskDescriptor(name="count_vpc", load=lambda: None, source="stock"),
+            cli.TaskDescriptor(name="noop", load=lambda: None, source="stock"),
             cli.TaskDescriptor(
-                name="custom_task", run=lambda: None, source="plugin: my-plugin"
+                name="custom_task", load=lambda: None, source="plugin: my-plugin"
             ),
         ],
     )
@@ -124,10 +124,10 @@ def test_cmd_list_processors_groups_by_source(monkeypatch, capsys):
         "list_processors",
         lambda: [
             cli.ProcessorDescriptor(
-                name="summary_json", run=lambda: None, source="stock"
+                name="summary_json", load=lambda: None, source="stock"
             ),
             cli.ProcessorDescriptor(
-                name="custom_report", run=lambda: None, source="plugin: my-plugin"
+                name="custom_report", load=lambda: None, source="plugin: my-plugin"
             ),
         ],
     )

--- a/tests/cli/test_validate_command.py
+++ b/tests/cli/test_validate_command.py
@@ -128,15 +128,6 @@ def test_validate_selected_tasks_validates_all_when_no_names(monkeypatch):
     cli = _import_cli_or_skip()
     seen = {}
 
-    monkeypatch.setattr(
-        cli,
-        "discover_tasks",
-        lambda: [
-            cli.TaskDescriptor(name="count_vpc", run=lambda: None, source="stock"),
-            cli.TaskDescriptor(name="noop", run=lambda: None, source="stock"),
-        ],
-    )
-
     def fake_load_task_callable(task_name):
         def run(*, account_id, account_alias, session, dry_run, metadata, actions):
             return None
@@ -144,10 +135,29 @@ def test_validate_selected_tasks_validates_all_when_no_names(monkeypatch):
         seen.setdefault("loaded", []).append(task_name)
         return run
 
+    monkeypatch.setattr(
+        cli,
+        "discover_tasks",
+        lambda: SimpleNamespace(
+            tasks=[
+                cli.TaskDescriptor(
+                    name="count_vpc",
+                    load=lambda: fake_load_task_callable("count_vpc"),
+                    source="stock",
+                ),
+                cli.TaskDescriptor(
+                    name="noop",
+                    load=lambda: fake_load_task_callable("noop"),
+                    source="stock",
+                ),
+            ],
+            issues=[],
+        ),
+    )
+
     def fake_validate_tasks(tasks):
         seen["validated"] = [task.name for task in tasks]
 
-    monkeypatch.setattr(cli, "_load_task_callable", fake_load_task_callable)
     monkeypatch.setattr(cli, "validate_tasks", fake_validate_tasks)
 
     cli._validate_selected_tasks([])
@@ -160,15 +170,6 @@ def test_validate_selected_tasks_validates_selected_names(monkeypatch):
     cli = _import_cli_or_skip()
     seen = {}
 
-    monkeypatch.setattr(
-        cli,
-        "discover_tasks",
-        lambda: [
-            cli.TaskDescriptor(name="count_vpc", run=lambda: None, source="stock"),
-            cli.TaskDescriptor(name="noop", run=lambda: None, source="stock"),
-        ],
-    )
-
     def fake_load_task_callable(task_name):
         def run(*, account_id, account_alias, session, dry_run, metadata, actions):
             return None
@@ -176,10 +177,29 @@ def test_validate_selected_tasks_validates_selected_names(monkeypatch):
         seen.setdefault("loaded", []).append(task_name)
         return run
 
+    monkeypatch.setattr(
+        cli,
+        "discover_tasks",
+        lambda: SimpleNamespace(
+            tasks=[
+                cli.TaskDescriptor(
+                    name="count_vpc",
+                    load=lambda: fake_load_task_callable("count_vpc"),
+                    source="stock",
+                ),
+                cli.TaskDescriptor(
+                    name="noop",
+                    load=lambda: fake_load_task_callable("noop"),
+                    source="stock",
+                ),
+            ],
+            issues=[],
+        ),
+    )
+
     def fake_validate_tasks(tasks):
         seen["validated"] = [task.name for task in tasks]
 
-    monkeypatch.setattr(cli, "_load_task_callable", fake_load_task_callable)
     monkeypatch.setattr(cli, "validate_tasks", fake_validate_tasks)
 
     cli._validate_selected_tasks(["noop"])
@@ -193,13 +213,64 @@ def test_validate_selected_tasks_reports_unknown_names(monkeypatch):
     monkeypatch.setattr(
         cli,
         "discover_tasks",
-        lambda: [
-            cli.TaskDescriptor(name="count_vpc", run=lambda: None, source="stock")
-        ],
+        lambda: SimpleNamespace(
+            tasks=[
+                cli.TaskDescriptor(name="count_vpc", load=lambda: None, source="stock")
+            ],
+            issues=[],
+        ),
     )
 
     with pytest.raises(ValueError, match="Unknown task"):
         cli._validate_selected_tasks(["missing"])
+
+
+def test_validate_all_tasks_reports_plugin_discovery_issues(monkeypatch):
+    cli = _import_cli_or_skip()
+    monkeypatch.setattr(
+        cli,
+        "discover_tasks",
+        lambda: SimpleNamespace(
+            tasks=[],
+            issues=[
+                cli.DiscoveryIssue(
+                    name="broken-plugin",
+                    source="plugin: broken-package",
+                    error="package import failed (missing dependency)",
+                )
+            ],
+        ),
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        cli._validate_selected_tasks([])
+
+    assert "broken-plugin (plugin: broken-package)" in str(exc_info.value)
+    assert "package import failed (missing dependency)" in str(exc_info.value)
+
+
+def test_validate_selected_unknown_task_reports_plugin_discovery_issues(monkeypatch):
+    cli = _import_cli_or_skip()
+    monkeypatch.setattr(
+        cli,
+        "discover_tasks",
+        lambda: SimpleNamespace(
+            tasks=[],
+            issues=[
+                cli.DiscoveryIssue(
+                    name="broken-plugin",
+                    source="plugin: broken-package",
+                    error="package import failed (missing dependency)",
+                )
+            ],
+        ),
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        cli._validate_selected_tasks(["plugin_task"])
+
+    assert "Unknown task(s): plugin_task" in str(exc_info.value)
+    assert "broken-plugin (plugin: broken-package)" in str(exc_info.value)
 
 
 def test_validate_selected_processors_validates_all_when_no_names(monkeypatch):
@@ -208,11 +279,15 @@ def test_validate_selected_processors_validates_all_when_no_names(monkeypatch):
 
     processors = [
         cli.ProcessorDescriptor(
-            name="summary_report", run=lambda: None, source="stock"
+            name="summary_report", load=lambda: None, source="stock"
         ),
-        cli.ProcessorDescriptor(name="html_export", run=lambda: None, source="stock"),
+        cli.ProcessorDescriptor(name="html_export", load=lambda: None, source="stock"),
     ]
-    monkeypatch.setattr(cli, "discover_processors", lambda: processors)
+    monkeypatch.setattr(
+        cli,
+        "discover_processors",
+        lambda: SimpleNamespace(processors=processors, issues=[]),
+    )
 
     def fake_validate_processors(processors):
         seen["validated"] = [processor.name for processor in processors]
@@ -230,11 +305,15 @@ def test_validate_selected_processors_validates_selected_names(monkeypatch):
 
     processors = [
         cli.ProcessorDescriptor(
-            name="summary_report", run=lambda: None, source="stock"
+            name="summary_report", load=lambda: None, source="stock"
         ),
-        cli.ProcessorDescriptor(name="html_export", run=lambda: None, source="stock"),
+        cli.ProcessorDescriptor(name="html_export", load=lambda: None, source="stock"),
     ]
-    monkeypatch.setattr(cli, "discover_processors", lambda: processors)
+    monkeypatch.setattr(
+        cli,
+        "discover_processors",
+        lambda: SimpleNamespace(processors=processors, issues=[]),
+    )
 
     def fake_validate_processors(processors):
         seen["validated"] = [processor.name for processor in processors]
@@ -252,14 +331,18 @@ def test_validate_selected_processors_preserves_duplicate_discoveries(monkeypatc
 
     processors = [
         cli.ProcessorDescriptor(
-            name="summary_report", run=lambda: None, source="stock"
+            name="summary_report", load=lambda: None, source="stock"
         ),
         cli.ProcessorDescriptor(
-            name="summary_report", run=lambda: None, source="plugin"
+            name="summary_report", load=lambda: None, source="plugin"
         ),
-        cli.ProcessorDescriptor(name="html_export", run=lambda: None, source="stock"),
+        cli.ProcessorDescriptor(name="html_export", load=lambda: None, source="stock"),
     ]
-    monkeypatch.setattr(cli, "discover_processors", lambda: processors)
+    monkeypatch.setattr(
+        cli,
+        "discover_processors",
+        lambda: SimpleNamespace(processors=processors, issues=[]),
+    )
 
     def fake_validate_processors(processors):
         seen["validated"] = [
@@ -281,15 +364,72 @@ def test_validate_selected_processors_reports_unknown_names(monkeypatch):
     monkeypatch.setattr(
         cli,
         "discover_processors",
-        lambda: [
-            cli.ProcessorDescriptor(
-                name="summary_report", run=lambda: None, source="stock"
-            )
-        ],
+        lambda: SimpleNamespace(
+            processors=[
+                cli.ProcessorDescriptor(
+                    name="summary_report", load=lambda: None, source="stock"
+                )
+            ],
+            issues=[],
+        ),
     )
 
     with pytest.raises(ValueError, match="Unknown processor"):
         cli._validate_selected_processors(["missing"])
+
+
+def test_validate_all_processors_reports_plugin_discovery_issues(monkeypatch):
+    cli = _import_cli_or_skip()
+    monkeypatch.setattr(
+        cli,
+        "discover_processors",
+        lambda: SimpleNamespace(
+            processors=[],
+            issues=[
+                cli.DiscoveryIssue(
+                    name="broken-plugin",
+                    source="plugin: broken-package",
+                    error="package import failed (missing dependency)",
+                )
+            ],
+        ),
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        cli._validate_selected_processors([])
+
+    assert "broken-plugin (plugin: broken-package)" in str(exc_info.value)
+    assert "package import failed (missing dependency)" in str(exc_info.value)
+
+
+def test_validate_selected_known_processor_ignores_unrelated_discovery_issues(
+    monkeypatch,
+):
+    cli = _import_cli_or_skip()
+
+    def run(*, context, output, metadata):
+        return None
+
+    monkeypatch.setattr(
+        cli,
+        "discover_processors",
+        lambda: SimpleNamespace(
+            processors=[
+                cli.ProcessorDescriptor(
+                    name="summary_report", load=lambda: run, source="stock"
+                )
+            ],
+            issues=[
+                cli.DiscoveryIssue(
+                    name="broken-plugin",
+                    source="plugin: broken-package",
+                    error="package import failed (missing dependency)",
+                )
+            ],
+        ),
+    )
+
+    cli._validate_selected_processors(["summary_report"])
 
 
 def test_validate_aggregates_failures_and_successes(monkeypatch, capsys):
@@ -324,7 +464,7 @@ def test_validate_aggregates_failures_and_successes(monkeypatch, capsys):
     assert "[OK]     Tasks" in output
     assert "[ERROR]  Processors" in output
     assert "[OK]     Authentication" in output
-    assert "Result: Failed" in output
+    assert "Result:" not in output
 
 
 def test_validate_treats_nonzero_auth_exit_code_as_failure(monkeypatch, capsys):
@@ -344,7 +484,7 @@ def test_validate_treats_nonzero_auth_exit_code_as_failure(monkeypatch, capsys):
     assert cli._cmd_validate(args) == 1
     output = capsys.readouterr().out
     assert "[ERROR]  Authentication" in output
-    assert "Result: Failed" in output
+    assert "Result:" not in output
 
 
 def test_validate_combined_categories_report_auth_failure(monkeypatch, capsys):
@@ -369,7 +509,7 @@ def test_validate_combined_categories_report_auth_failure(monkeypatch, capsys):
     assert "[OK]     Tasks" in output
     assert "[OK]     Processors" in output
     assert "[ERROR]  Authentication" in output
-    assert "Result: Failed" in output
+    assert "Result:" not in output
 
 
 def test_validate_tasks_and_processors_report_success(monkeypatch, capsys):
@@ -391,7 +531,7 @@ def test_validate_tasks_and_processors_report_success(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "[OK]     Tasks" in output
     assert "[OK]     Processors" in output
-    assert "Result: Success" in output
+    assert "Result:" not in output
 
 
 def test_validate_task_failure_reports_failed_result(monkeypatch, capsys):
@@ -417,7 +557,7 @@ def test_validate_task_failure_reports_failed_result(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "[ERROR]  Tasks" in output
     assert "task 'count_vpc' is missing required run() parameters" in output
-    assert "Result: Failed" in output
+    assert "Result:" not in output
 
 
 def test_validate_auth_uses_quiet_auth_check(monkeypatch):
@@ -494,4 +634,4 @@ def test_validate_returns_success_when_all_categories_pass(monkeypatch, capsys):
     monkeypatch.setattr(cli, "_validate_selected_processors", lambda _: None)
 
     assert cli._cmd_validate(args) == 0
-    assert "Result: Success" in capsys.readouterr().out
+    assert "Result:" not in capsys.readouterr().out

--- a/tests/cli/test_validate_command.py
+++ b/tests/cli/test_validate_command.py
@@ -155,10 +155,11 @@ def test_validate_selected_tasks_validates_all_when_no_names(monkeypatch):
         ),
     )
 
-    def fake_validate_tasks(tasks):
+    def fake_task_validation_errors(tasks):
         seen["validated"] = [task.name for task in tasks]
+        return []
 
-    monkeypatch.setattr(cli, "validate_tasks", fake_validate_tasks)
+    monkeypatch.setattr(cli, "task_validation_errors", fake_task_validation_errors)
 
     cli._validate_selected_tasks([])
 
@@ -197,10 +198,11 @@ def test_validate_selected_tasks_validates_selected_names(monkeypatch):
         ),
     )
 
-    def fake_validate_tasks(tasks):
+    def fake_task_validation_errors(tasks):
         seen["validated"] = [task.name for task in tasks]
+        return []
 
-    monkeypatch.setattr(cli, "validate_tasks", fake_validate_tasks)
+    monkeypatch.setattr(cli, "task_validation_errors", fake_task_validation_errors)
 
     cli._validate_selected_tasks(["noop"])
 
@@ -289,10 +291,13 @@ def test_validate_selected_processors_validates_all_when_no_names(monkeypatch):
         lambda: SimpleNamespace(processors=processors, issues=[]),
     )
 
-    def fake_validate_processors(processors):
+    def fake_processor_validation_errors(processors):
         seen["validated"] = [processor.name for processor in processors]
+        return []
 
-    monkeypatch.setattr(cli, "validate_processors", fake_validate_processors)
+    monkeypatch.setattr(
+        cli, "processor_validation_errors", fake_processor_validation_errors
+    )
 
     cli._validate_selected_processors([])
 
@@ -315,10 +320,13 @@ def test_validate_selected_processors_validates_selected_names(monkeypatch):
         lambda: SimpleNamespace(processors=processors, issues=[]),
     )
 
-    def fake_validate_processors(processors):
+    def fake_processor_validation_errors(processors):
         seen["validated"] = [processor.name for processor in processors]
+        return []
 
-    monkeypatch.setattr(cli, "validate_processors", fake_validate_processors)
+    monkeypatch.setattr(
+        cli, "processor_validation_errors", fake_processor_validation_errors
+    )
 
     cli._validate_selected_processors(["html_export"])
 
@@ -344,12 +352,15 @@ def test_validate_selected_processors_preserves_duplicate_discoveries(monkeypatc
         lambda: SimpleNamespace(processors=processors, issues=[]),
     )
 
-    def fake_validate_processors(processors):
+    def fake_processor_validation_errors(processors):
         seen["validated"] = [
             (processor.name, processor.source) for processor in processors
         ]
+        return []
 
-    monkeypatch.setattr(cli, "validate_processors", fake_validate_processors)
+    monkeypatch.setattr(
+        cli, "processor_validation_errors", fake_processor_validation_errors
+    )
 
     cli._validate_selected_processors(["summary_report"])
 

--- a/tests/processors/test_processors.py
+++ b/tests/processors/test_processors.py
@@ -31,7 +31,7 @@ def test_validate_processors_accepts_valid_processor():
         return None
 
     validate_processors(
-        [ProcessorDescriptor(name="summary", run=lambda: run, source="stock")]
+        [ProcessorDescriptor(name="summary", load=lambda: run, source="stock")]
     )
 
 
@@ -42,8 +42,8 @@ def test_validate_processors_rejects_duplicate_names():
     with pytest.raises(ProcessorValidationError, match="duplicate processor name"):
         validate_processors(
             [
-                ProcessorDescriptor(name="summary", run=lambda: run, source="stock"),
-                ProcessorDescriptor(name="summary", run=lambda: run, source="plugin"),
+                ProcessorDescriptor(name="summary", load=lambda: run, source="stock"),
+                ProcessorDescriptor(name="summary", load=lambda: run, source="plugin"),
             ]
         )
 
@@ -54,7 +54,7 @@ def test_validate_processors_rejects_missing_contract_parameter():
 
     with pytest.raises(ProcessorValidationError, match="metadata"):
         validate_processors(
-            [ProcessorDescriptor(name="summary", run=lambda: run, source="stock")]
+            [ProcessorDescriptor(name="summary", load=lambda: run, source="stock")]
         )
 
 

--- a/tests/tasks/test_task_loader.py
+++ b/tests/tasks/test_task_loader.py
@@ -73,11 +73,11 @@ def test_list_tasks_sorted_by_source_then_name():
 
 
 def test_discover_tasks_includes_stock_tasks():
-    tasks = discover_tasks()
+    tasks = discover_tasks().tasks
     names = {task.name for task in tasks}
 
     assert "noop" in names
 
     noop = next(task for task in tasks if task.name == "noop")
     assert noop.source == "stock"
-    assert callable(noop.run)
+    assert callable(noop.load)

--- a/tests/tasks/test_task_validation.py
+++ b/tests/tasks/test_task_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from anvil.task_loader import TaskDescriptor
+from anvil.task_loader import ResolvedTask
 from anvil.task_validation import TaskValidationError, validate_tasks
 
 
@@ -8,7 +8,7 @@ def test_validate_tasks_accepts_valid_task():
     def run(*, account_id, account_alias, session, dry_run, metadata, actions=None):
         pass
 
-    task = TaskDescriptor(name="valid", run=run, source="stock")
+    task = ResolvedTask(name="valid", run=run, depends_on=[], optional=False)
 
     validate_tasks([task])
 
@@ -17,7 +17,7 @@ def test_validate_tasks_accepts_var_keyword_task():
     def run(**kwargs):
         pass
 
-    task = TaskDescriptor(name="valid", run=run, source="stock")
+    task = ResolvedTask(name="valid", run=run, depends_on=[], optional=False)
 
     validate_tasks([task])
 
@@ -26,7 +26,7 @@ def test_validate_tasks_rejects_task_missing_actions():
     def run(*, account_id, account_alias, session, dry_run, metadata):
         pass
 
-    task = TaskDescriptor(name="missing-actions", run=run, source="stock")
+    task = ResolvedTask(name="missing-actions", run=run, depends_on=[], optional=False)
 
     with pytest.raises(TaskValidationError):
         validate_tasks([task])
@@ -36,7 +36,7 @@ def test_validate_tasks_rejects_bad_signature():
     def run(account_id):  # missing required kwargs
         pass
 
-    task = TaskDescriptor(name="bad", run=run, source="stock")
+    task = ResolvedTask(name="bad", run=run, depends_on=[], optional=False)
 
     with pytest.raises(TaskValidationError):
         validate_tasks([task])
@@ -46,7 +46,10 @@ def test_validate_tasks_rejects_duplicate_names():
     def run(*, account_id, account_alias, session, dry_run, metadata, actions=None):
         pass
 
-    tasks = [TaskDescriptor("dup", run, "stock"), TaskDescriptor("dup", run, "plugin")]
+    tasks = [
+        ResolvedTask("dup", run, depends_on=[], optional=False),
+        ResolvedTask("dup", run, depends_on=[], optional=False),
+    ]
 
     with pytest.raises(TaskValidationError):
         validate_tasks(tasks)

--- a/tests/test_loader_plugin_entry_points.py
+++ b/tests/test_loader_plugin_entry_points.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 
+import pytest
+
 from anvil import processor_loader, task_loader
 
 
@@ -52,6 +54,30 @@ def test_resolve_tasks_loads_real_plugin_entry_point(monkeypatch, tmp_path):
 
     assert execution.ordered[0].name == "real_plugin_task"
     assert execution.ordered[0].run() == {"source": "plugin-task"}
+
+
+def test_resolve_tasks_reports_plugin_dependency_import_error(monkeypatch, tmp_path):
+    _write_plugin_distribution(
+        root=tmp_path,
+        distribution_name="anvil-test-broken-task-plugin",
+        package_name="anvil_test_broken_task_plugin",
+        entry_point_group=task_loader.TASK_ENTRY_POINT_GROUP,
+        entry_point_name="test-broken-task-plugin",
+        module_name="broken_plugin_task",
+        module_body="import missing_dependency\n\ndef run(**kwargs):\n    return None\n",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+    task_loader._load_task_callable.cache_clear()
+    task_loader._resolve_tasks_cached.cache_clear()
+
+    with pytest.raises(task_loader.TaskConfigError) as exc_info:
+        task_loader.resolve_tasks(task_specs=[{"name": "broken_plugin_task"}])
+
+    error = str(exc_info.value)
+    assert "Plugin task 'broken_plugin_task'" in error
+    assert "failed during import" in error
+    assert "missing_dependency" in error
 
 
 def test_discover_tasks_includes_real_plugin_entry_point(monkeypatch, tmp_path):

--- a/tests/test_loader_plugin_entry_points.py
+++ b/tests/test_loader_plugin_entry_points.py
@@ -67,13 +67,13 @@ def test_discover_tasks_includes_real_plugin_entry_point(monkeypatch, tmp_path):
     monkeypatch.syspath_prepend(str(tmp_path))
     importlib.invalidate_caches()
 
-    descriptors = task_loader.discover_tasks()
+    descriptors = task_loader.discover_tasks().tasks
     descriptor = next(
         task for task in descriptors if task.name == "discoverable_plugin_task"
     )
 
     assert descriptor.source == "plugin: anvil-test-task-discovery-plugin"
-    assert descriptor.run()() == {"source": "plugin-task"}
+    assert descriptor.load()() == {"source": "plugin-task"}
 
 
 def test_discover_processors_includes_real_plugin_entry_point(monkeypatch, tmp_path):
@@ -93,7 +93,7 @@ def test_discover_processors_includes_real_plugin_entry_point(monkeypatch, tmp_p
     importlib.invalidate_caches()
     processor_loader.load_processor_callable.cache_clear()
 
-    descriptors = processor_loader.discover_processors()
+    descriptors = processor_loader.discover_processors().processors
     descriptor = next(
         processor
         for processor in descriptors
@@ -101,6 +101,6 @@ def test_discover_processors_includes_real_plugin_entry_point(monkeypatch, tmp_p
     )
 
     assert descriptor.source == "plugin: anvil-test-processor-plugin"
-    assert descriptor.run()(
+    assert descriptor.load()(
         context=None, output="report.md", metadata={"ok": True}
     ) == {"output": "report.md", "metadata": {"ok": True}}


### PR DESCRIPTION
This changes task and processor discovery to return discovery results instead of raw descriptor lists. Discovery results include both discovered descriptors and non-fatal plugin discovery issues, allowing validation commands to report broken plugin imports instead of silently skipping them.

*Breaking Change*
discover_tasks() and discover_processors() no longer return plain lists.


*Behavior Changes*

- anvil validate --tasks and anvil validate --processors now report plugin package import failures discovered while inspecting installed plugins.
- Plugin modules that exist but fail due to missing dependencies now report an import failure instead of being treated as missing.
- Validation no longer reparses formatted exception text internally; task and processor validators expose structured error-list helpers.
- Validation output no longer prints the trailing Result: Success or Result: Failed line.

## Checklist
- [x] Python format, lint, and tests (`ruff` and `pytest`) were successful.
- [x] Pre-commit hooks passed locally.
- [x] Documentation updated if needed.
- [x] Unit tests added or updated.
