### PR TITLE
Fix/base session role assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,10 @@ organizations:
 ```
 
 For delegated-administrator patterns, keep the base session on the
-delegated-admin profile and set `assume_role_in_management: true` so Anvil
-assumes `role_name` in the management/payer account just like it would in the
-rest of the member accounts. That role must exist in all member accounts and in
-the management/payer account; delegated-admin StackSets usually do not deploy
-into the management account, so that role often needs to be created separately
-there.
+delegated-admin profile. Anvil uses that base session directly for the
+delegated-admin account if it appears in Organizations discovery, and assumes
+`role_name` in every other selected account, including the management/payer
+account.
 
 ```yaml
 schema_version: 1
@@ -117,7 +115,6 @@ organizations:
   - name: security
     profile: delegated-admin-security
     role_name: SecurityAuditRole
-    assume_role_in_management: true
     regions:
       - us-east-1
     tasks:

--- a/examples/12-delegated-admin-org.yaml
+++ b/examples/12-delegated-admin-org.yaml
@@ -4,7 +4,6 @@ organizations:
   - name: security
     profile: delegated-admin-security
     role_name: SecurityAuditRole
-    assume_role_in_management: true
     regions:
       - us-east-1
     tasks:

--- a/examples/13-complete-org-reference.yaml
+++ b/examples/13-complete-org-reference.yaml
@@ -6,10 +6,9 @@ organizations:
     profile: place-root
     # Organizations support explicit regions, all by itself, glob selectors,
     # and mixed glob plus explicit selectors.
-    # Delegated administrator workflows can set assume_role_in_management: true
-    # to make the management/payer account assume role_name just like member
-    # accounts. The role must exist in all member accounts and in the
-    # management/payer account.
+    # Anvil uses the base-session account directly when it appears in
+    # Organizations discovery, and assumes role_name in every other selected
+    # account.
     regions:
       - us-east-1
       - us-west-2

--- a/src/anvil/account.py
+++ b/src/anvil/account.py
@@ -13,6 +13,7 @@ from concurrent.futures import (
     wait,
 )
 from dataclasses import dataclass, field
+from enum import StrEnum
 
 import boto3
 from boto3.session import Session
@@ -27,6 +28,16 @@ __LOGGER__ = logging.getLogger(__name__)
 
 MINIMUM_ASSUMED_CREDENTIAL_REFRESH_WINDOW = datetime.timedelta(minutes=5)
 ASSUMED_CREDENTIAL_REFRESH_BUFFER = datetime.timedelta(minutes=2)
+
+
+class AccountAccessStrategy(StrEnum):
+    """
+    Credential path used to access an executable account.
+    """
+
+    BASE_SESSION = "base_session"
+    ASSUME_ROLE = "assume_role"
+    DIRECT_PROFILE = "direct_profile"
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,7 +63,7 @@ class Account:
 
     Owns:
     - account identity
-    - management vs member behavior
+    - access strategy
     - execution lifecycle
 
     Does NOT own:
@@ -67,7 +78,7 @@ class Account:
         account_id: str,
         account_alias: str,
         is_management: bool,
-        assume_role: bool,
+        access_strategy: AccountAccessStrategy,
         base_session: boto3.Session,
         context: ExecutionContext,
         regions: list[str],
@@ -76,7 +87,7 @@ class Account:
         self.account_id: str = account_id
         self.account_alias: str = account_alias
         self.is_management: bool = is_management
-        self._assume_role: bool = assume_role
+        self.access_strategy: AccountAccessStrategy = access_strategy
         self._base_session: Session = base_session
         self._context: ExecutionContext = context
         self._regions: list[str] = regions
@@ -101,13 +112,14 @@ class Account:
             recorder = BenchmarkRecorder(enabled=self._context.benchmark_enabled)
             recorder.update(
                 {
+                    "access_strategy": self.access_strategy.value,
                     "assume_role_seconds": 0.0,
                     "assume_role_refresh_count": 0,
                     "direct_access_validation_seconds": 0.0,
                 }
             )
 
-            if self._assume_role:
+            if self.access_strategy is AccountAccessStrategy.ASSUME_ROLE:
                 with recorder.phase("assume_role_seconds"):
                     assumed_credential_state = _AssumedCredentialState(
                         credentials=self._get_assumed_role_credentials()
@@ -569,18 +581,19 @@ class Account:
         """
         Build the execution session for one account-region pair.
 
-        Management accounts use the org/profile-backed worker session directly.
+        Base-session and direct-profile accounts use the profile-backed worker
+        session directly.
         Assume-role execution builds a regional session from the already-assumed
         temporary credentials.
         """
-        if not self._assume_role:
+        if self.access_strategy is not AccountAccessStrategy.ASSUME_ROLE:
             return self._session_factory.get_worker_session(
                 profile_name=self._base_session.profile_name, region_name=region
             )
 
         if assumed_credential_state is None:
             raise ValueError(
-                "Expected assumed credentials for member account execution"
+                "Expected assumed credentials for assume-role account execution"
             )
 
         assumed_credentials = self._get_valid_assumed_role_credentials(

--- a/src/anvil/account_resolver.py
+++ b/src/anvil/account_resolver.py
@@ -4,7 +4,7 @@ import logging
 
 from boto3.session import Session
 
-from anvil.account import Account
+from anvil.account import Account, AccountAccessStrategy
 from anvil.descriptors import TargetDescriptor
 from anvil.execution_context import ExecutionContext
 from anvil.session import SessionFactory
@@ -42,12 +42,17 @@ class AccountResolver:
         accounts: list[Account] = []
 
         for account_id in self.descriptor.include or []:
+            access_strategy = (
+                AccountAccessStrategy.ASSUME_ROLE
+                if self.descriptor.role_name is not None
+                else AccountAccessStrategy.DIRECT_PROFILE
+            )
             accounts.append(
                 Account(
                     account_id=account_id,
                     account_alias=account_id,
                     is_management=False,
-                    assume_role=self.descriptor.role_name is not None,
+                    access_strategy=access_strategy,
                     base_session=base_session,
                     context=self.context,
                     regions=list(self.context.regions),

--- a/src/anvil/descriptors.py
+++ b/src/anvil/descriptors.py
@@ -33,7 +33,6 @@ class TargetDescriptor:
     max_parallel_regions: int = 1
     fail_fast: bool = False
     dry_run: bool = False
-    assume_role_in_management: bool = False
 
     include: list[str] | None = None
     exclude: list[str] | None = None
@@ -90,11 +89,6 @@ class TargetDescriptor:
             return
 
         if self.config_branch is ConfigBranch.ACCOUNTS:
-            if self.assume_role_in_management:
-                raise ValueError(
-                    "assume_role_in_management is only supported for organizations"
-                )
-
             account_region_selectors = [
                 region for region in self.regions if is_region_selector(region)
             ]

--- a/src/anvil/execution_context.py
+++ b/src/anvil/execution_context.py
@@ -20,7 +20,6 @@ class ExecutionContext:
 
     fail_fast: bool = False
     max_parallel_regions: int = 1
-    assume_role_in_management: bool = False
     benchmark_enabled: bool = False
     log_level: str | int | None = None
     cancel_event: threading.Event = field(default_factory=threading.Event)

--- a/src/anvil/organization.py
+++ b/src/anvil/organization.py
@@ -5,7 +5,7 @@ import logging
 import boto3
 from boto3.session import Session
 
-from anvil.account import Account
+from anvil.account import Account, AccountAccessStrategy
 from anvil.descriptors import TargetDescriptor
 from anvil.execution_context import ExecutionContext
 from anvil.regions import get_bootstrap_region, resolve_region_selectors
@@ -25,6 +25,7 @@ class OrganizationResolver:
         descriptor: TargetDescriptor,
         context: ExecutionContext,
         management_account_id: str | None = None,
+        base_session_account_id: str | None = None,
         session_factory: SessionFactory | None = None,
         base_session: Session | None = None,
         discovered_accounts: dict[str, dict[str, str]] | None = None,
@@ -33,6 +34,7 @@ class OrganizationResolver:
         self.descriptor = descriptor
         self.context = context
         self._management_account_id: str | None = management_account_id
+        self._base_session_account_id: str | None = base_session_account_id
         self._session_factory = session_factory or SessionFactory()
         self._base_session = base_session
         self._discovered_accounts = discovered_accounts
@@ -63,9 +65,15 @@ class OrganizationResolver:
         else:
             _, management_account_id = self.describe_organization(base_session)
 
+        if self._base_session_account_id is not None:
+            base_session_account_id = self._base_session_account_id
+        else:
+            base_session_account_id = self.describe_base_session_account(base_session)
+
         return self._build_accounts(
             base_session=base_session,
             management_account_id=management_account_id,
+            base_session_account_id=base_session_account_id,
             effective_regions=effective_regions,
             discovered_accounts=self._discovered_accounts,
         )
@@ -79,11 +87,20 @@ class OrganizationResolver:
         org = org_client.describe_organization()["Organization"]
         return org["Id"], org["MasterAccountId"]
 
+    @staticmethod
+    def describe_base_session_account(session: boto3.Session) -> str:
+        """
+        Return the AWS account ID backing the base session credentials.
+        """
+        sts_client = session.client("sts", config=BOTO_CONFIG)
+        return sts_client.get_caller_identity()["Account"]
+
     def _build_accounts(
         self,
         *,
         base_session: boto3.Session,
         management_account_id: str,
+        base_session_account_id: str,
         effective_regions: list[str],
         discovered_accounts: dict[str, dict[str, str]] | None = None,
     ) -> list[Account]:
@@ -98,14 +115,17 @@ class OrganizationResolver:
         for info in target_accounts.values():
             account_id = info["account_number"]
             is_management = account_id == management_account_id
+            access_strategy = (
+                AccountAccessStrategy.BASE_SESSION
+                if account_id == base_session_account_id
+                else AccountAccessStrategy.ASSUME_ROLE
+            )
             accounts.append(
                 Account(
                     account_id=account_id,
                     account_alias=info["account_alias"],
                     is_management=is_management,
-                    assume_role=(
-                        not is_management or self.context.assume_role_in_management
-                    ),
+                    access_strategy=access_strategy,
                     base_session=base_session,
                     context=self.context,
                     regions=effective_regions,

--- a/src/anvil/runner.py
+++ b/src/anvil/runner.py
@@ -110,6 +110,7 @@ class PreparedTarget:
     base_session: Session | None = None
     organization_id: str | None = None
     management_account_id: str | None = None
+    base_session_account_id: str | None = None
     discovered_accounts: dict[str, dict[str, str]] | None = None
     region_statuses: dict[str, str] | None = None
     benchmark: dict[str, object] | None = None
@@ -325,7 +326,6 @@ def _build_execution_context(
         metadata=target.metadata,
         fail_fast=target.fail_fast,
         max_parallel_regions=target.max_parallel_regions,
-        assume_role_in_management=target.assume_role_in_management,
         benchmark_enabled=benchmark_enabled,
     )
 
@@ -337,7 +337,7 @@ def _preflight_organization(
     session_factory: SessionFactory,
     organization_cache: OrganizationRunCache,
     benchmark: dict[str, object] | None = None,
-) -> tuple[Session, str, str, dict[str, dict[str, str]], dict[str, str]]:
+) -> tuple[Session, str, str, str, dict[str, dict[str, str]], dict[str, str]]:
     sink = BenchmarkRecorder(data=benchmark)
 
     with sink.phase("create_base_session_seconds"):
@@ -349,6 +349,11 @@ def _preflight_organization(
     with sink.phase("describe_organization_seconds"):
         organization_id, management_account_id = (
             OrganizationResolver.describe_organization(base_session)
+        )
+
+    with sink.phase("describe_base_session_account_seconds"):
+        base_session_account_id = OrganizationResolver.describe_base_session_account(
+            base_session
         )
 
     def discover_organization() -> OrganizationRunCacheEntry:
@@ -376,6 +381,7 @@ def _preflight_organization(
         base_session,
         organization_id,
         lookup.entry.management_account_id,
+        base_session_account_id,
         lookup.entry.discovered_accounts,
         lookup.entry.region_statuses,
     )
@@ -430,6 +436,7 @@ def prepare_target(
         base_session: Session | None = None
         organization_id: str | None = None
         management_account_id: str | None = None
+        base_session_account_id: str | None = None
         discovered_accounts: dict[str, dict[str, str]] | None = None
         region_statuses: dict[str, str] | None = None
         if effective_target.is_organization_config:
@@ -437,6 +444,7 @@ def prepare_target(
                 base_session,
                 organization_id,
                 management_account_id,
+                base_session_account_id,
                 discovered_accounts,
                 region_statuses,
             ) = _preflight_organization(
@@ -456,6 +464,7 @@ def prepare_target(
         base_session=base_session,
         organization_id=organization_id,
         management_account_id=management_account_id,
+        base_session_account_id=base_session_account_id,
         discovered_accounts=discovered_accounts,
         region_statuses=region_statuses,
         benchmark=recorder.data,
@@ -474,6 +483,7 @@ def run_prepared_target(*, prepared_target: PreparedTarget) -> TargetExecutionOu
             descriptor=target,
             context=context,
             management_account_id=prepared_target.management_account_id,
+            base_session_account_id=prepared_target.base_session_account_id,
             session_factory=prepared_target.session_factory,
             base_session=prepared_target.base_session,
             discovered_accounts=prepared_target.discovered_accounts,

--- a/src/anvil/schemas/orgs.schema.v1.json
+++ b/src/anvil/schemas/orgs.schema.v1.json
@@ -61,11 +61,6 @@
           "role_name": {
             "$ref": "common.schema.v1.json#/$defs/baseTargetProperties/role_name"
           },
-          "assume_role_in_management": {
-            "type": "boolean",
-            "default": false,
-            "description": "If true, the management/payer account uses the same configured role-assumption path as member accounts. This supports delegated-administrator broker workflows."
-          },
           "tasks": {
             "$ref": "common.schema.v1.json#/$defs/baseTargetProperties/tasks"
           },

--- a/tests/runner/test_account_execution.py
+++ b/tests/runner/test_account_execution.py
@@ -9,6 +9,7 @@ from anvil.account import (
     ASSUMED_CREDENTIAL_REFRESH_BUFFER,
     MINIMUM_ASSUMED_CREDENTIAL_REFRESH_WINDOW,
     Account,
+    AccountAccessStrategy,
 )
 from anvil.execution_context import ExecutionContext
 from anvil.results import ExecutionStatus
@@ -107,7 +108,7 @@ def _account(
     *,
     tasks: list[ResolvedTask],
     session_factory: RecordingSessionFactory | None = None,
-    assume_role: bool = False,
+    access_strategy: AccountAccessStrategy = AccountAccessStrategy.DIRECT_PROFILE,
     regions: list[str] | None = None,
     max_parallel_regions: int = 1,
 ) -> Account:
@@ -115,8 +116,8 @@ def _account(
     return Account(
         account_id="123456789012",
         account_alias="test-account",
-        is_management=not assume_role,
-        assume_role=assume_role,
+        is_management=access_strategy is AccountAccessStrategy.BASE_SESSION,
+        access_strategy=access_strategy,
         base_session=BaseSession(),
         context=_context(
             tasks=tasks,
@@ -216,7 +217,7 @@ def test_assume_role_path_reuses_assumed_credentials_for_regions():
     account = _account(
         tasks=[],
         session_factory=session_factory,
-        assume_role=True,
+        access_strategy=AccountAccessStrategy.ASSUME_ROLE,
         regions=["us-east-1", "us-west-2"],
     )
 
@@ -243,7 +244,7 @@ def test_assume_role_path_refreshes_expiring_credentials_before_region():
     account = _account(
         tasks=[],
         session_factory=session_factory,
-        assume_role=True,
+        access_strategy=AccountAccessStrategy.ASSUME_ROLE,
         regions=["us-east-1"],
     )
 
@@ -286,7 +287,7 @@ def test_assume_role_parallel_regions_refresh_credentials_once():
     account = _account(
         tasks=[ResolvedTask("blocking", blocking_task, depends_on=[], optional=False)],
         session_factory=session_factory,
-        assume_role=True,
+        access_strategy=AccountAccessStrategy.ASSUME_ROLE,
         regions=["us-east-1", "us-west-2"],
         max_parallel_regions=2,
     )
@@ -349,7 +350,7 @@ def test_sequential_regions_use_adaptive_refresh_window(monkeypatch):
     account = _account(
         tasks=[ResolvedTask("task", task, depends_on=[], optional=False)],
         session_factory=session_factory,
-        assume_role=True,
+        access_strategy=AccountAccessStrategy.ASSUME_ROLE,
         regions=["us-east-1", "us-west-2"],
     )
 
@@ -495,7 +496,7 @@ def test_parallel_account_cancelled_before_regions_start_is_interrupted():
         account_id="123456789012",
         account_alias="test-account",
         is_management=True,
-        assume_role=False,
+        access_strategy=AccountAccessStrategy.BASE_SESSION,
         base_session=BaseSession(),
         context=context,
         regions=["us-east-1", "us-west-2"],

--- a/tests/runner/test_account_resolver.py
+++ b/tests/runner/test_account_resolver.py
@@ -13,11 +13,7 @@ class FakeSessionFactory:
 
 def _context(*, role_name: str | None = None) -> ExecutionContext:
     return ExecutionContext(
-        regions=["us-east-1"],
-        role_name=role_name,
-        dry_run=True,
-        tasks=[],
-        metadata={},
+        regions=["us-east-1"], role_name=role_name, dry_run=True, tasks=[], metadata={}
     )
 
 
@@ -32,9 +28,7 @@ def test_resolve_accounts_uses_assume_role_strategy_when_role_name_is_configured
     context = _context(role_name="SecurityAccessRole")
 
     accounts = AccountResolver(
-        descriptor=descriptor,
-        context=context,
-        session_factory=FakeSessionFactory(),
+        descriptor=descriptor, context=context, session_factory=FakeSessionFactory()
     ).resolve_accounts()
 
     assert [account.account_id for account in accounts] == [
@@ -57,9 +51,7 @@ def test_resolve_accounts_uses_direct_profile_strategy_without_role_name():
     context = _context()
 
     accounts = AccountResolver(
-        descriptor=descriptor,
-        context=context,
-        session_factory=FakeSessionFactory(),
+        descriptor=descriptor, context=context, session_factory=FakeSessionFactory()
     ).resolve_accounts()
 
     assert [account.account_id for account in accounts] == ["111111111111"]

--- a/tests/runner/test_account_resolver.py
+++ b/tests/runner/test_account_resolver.py
@@ -11,10 +11,10 @@ class FakeSessionFactory:
         return type("_BaseSession", (), {"profile_name": kwargs["profile_name"]})()
 
 
-def _context() -> ExecutionContext:
+def _context(*, role_name: str | None = None) -> ExecutionContext:
     return ExecutionContext(
         regions=["us-east-1"],
-        role_name=None,
+        role_name=role_name,
         dry_run=True,
         tasks=[],
         metadata={},
@@ -29,7 +29,7 @@ def test_resolve_accounts_uses_assume_role_strategy_when_role_name_is_configured
         role_name="SecurityAccessRole",
         include=["111111111111", "222222222222"],
     )
-    context = _context()
+    context = _context(role_name="SecurityAccessRole")
 
     accounts = AccountResolver(
         descriptor=descriptor,

--- a/tests/runner/test_account_resolver.py
+++ b/tests/runner/test_account_resolver.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from anvil.account import AccountAccessStrategy
+from anvil.account_resolver import AccountResolver
+from anvil.descriptors import ConfigBranch, TargetDescriptor
+from anvil.execution_context import ExecutionContext
+
+
+class FakeSessionFactory:
+    def create_base_session(self, **kwargs):
+        return type("_BaseSession", (), {"profile_name": kwargs["profile_name"]})()
+
+
+def _context() -> ExecutionContext:
+    return ExecutionContext(
+        regions=["us-east-1"],
+        role_name=None,
+        dry_run=True,
+        tasks=[],
+        metadata={},
+    )
+
+
+def test_resolve_accounts_uses_assume_role_strategy_when_role_name_is_configured():
+    descriptor = TargetDescriptor(
+        config_branch=ConfigBranch.ACCOUNTS,
+        name="selected",
+        profile="tooling",
+        role_name="SecurityAccessRole",
+        include=["111111111111", "222222222222"],
+    )
+    context = _context()
+
+    accounts = AccountResolver(
+        descriptor=descriptor,
+        context=context,
+        session_factory=FakeSessionFactory(),
+    ).resolve_accounts()
+
+    assert [account.account_id for account in accounts] == [
+        "111111111111",
+        "222222222222",
+    ]
+    assert [account.access_strategy for account in accounts] == [
+        AccountAccessStrategy.ASSUME_ROLE,
+        AccountAccessStrategy.ASSUME_ROLE,
+    ]
+
+
+def test_resolve_accounts_uses_direct_profile_strategy_without_role_name():
+    descriptor = TargetDescriptor(
+        config_branch=ConfigBranch.ACCOUNTS,
+        name="current",
+        profile="dev-admin",
+        include=["111111111111"],
+    )
+    context = _context()
+
+    accounts = AccountResolver(
+        descriptor=descriptor,
+        context=context,
+        session_factory=FakeSessionFactory(),
+    ).resolve_accounts()
+
+    assert [account.account_id for account in accounts] == ["111111111111"]
+    assert accounts[0].access_strategy is AccountAccessStrategy.DIRECT_PROFILE

--- a/tests/runner/test_organization_resolver.py
+++ b/tests/runner/test_organization_resolver.py
@@ -4,6 +4,7 @@ import pytest
 
 from anvil.descriptors import ConfigBranch, TargetDescriptor
 from anvil.execution_context import ExecutionContext
+from anvil.account import AccountAccessStrategy
 from anvil.organization import OrganizationResolver
 
 
@@ -36,16 +37,13 @@ class FailingSessionFactory:
         raise AssertionError("preflight base_session should be reused")
 
 
-def _context(
-    *, regions: list[str] | None = None, assume_role_in_management: bool = False
-) -> ExecutionContext:
+def _context(*, regions: list[str] | None = None) -> ExecutionContext:
     return ExecutionContext(
         regions=regions or ["us-east-1"],
         role_name="TestRole",
         dry_run=True,
         tasks=[],
         metadata={},
-        assume_role_in_management=assume_role_in_management,
     )
 
 
@@ -171,6 +169,7 @@ def test_resolve_accounts_uses_default_management_account_direct_mode():
         descriptor=_target(regions=["us-east-1", "us-west-2"]),
         context=_context(regions=["us-east-1", "us-west-2"]),
         management_account_id="111111111111",
+        base_session_account_id="111111111111",
         session_factory=FailingSessionFactory(),
         base_session=base_session,
         discovered_accounts=discovered_accounts,
@@ -184,18 +183,19 @@ def test_resolve_accounts_uses_default_management_account_direct_mode():
         "222222222222",
     ]
     assert accounts[0].is_management is True
-    assert accounts[0]._assume_role is False
+    assert accounts[0].access_strategy is AccountAccessStrategy.BASE_SESSION
     assert accounts[1].is_management is False
-    assert accounts[1]._assume_role is True
+    assert accounts[1].access_strategy is AccountAccessStrategy.ASSUME_ROLE
     assert accounts[0]._regions == ["us-east-1"]
     assert accounts[1]._regions == ["us-east-1"]
 
 
 def test_resolve_accounts_uses_explicit_management_account_direct_mode():
     resolver = OrganizationResolver(
-        descriptor=_target(assume_role_in_management=False),
-        context=_context(assume_role_in_management=False),
+        descriptor=_target(),
+        context=_context(),
         management_account_id="111111111111",
+        base_session_account_id="111111111111",
         base_session=object(),
         discovered_accounts={
             "111111111111": {
@@ -212,14 +212,18 @@ def test_resolve_accounts_uses_explicit_management_account_direct_mode():
 
     accounts = resolver.resolve_accounts()
 
-    assert [account._assume_role for account in accounts] == [False, True]
+    assert [account.access_strategy for account in accounts] == [
+        AccountAccessStrategy.BASE_SESSION,
+        AccountAccessStrategy.ASSUME_ROLE,
+    ]
 
 
-def test_resolve_accounts_assumes_role_in_management_when_configured():
+def test_resolve_accounts_uses_base_session_account_direct_mode_for_delegated_admin():
     resolver = OrganizationResolver(
-        descriptor=_target(assume_role_in_management=True),
-        context=_context(assume_role_in_management=True),
+        descriptor=_target(),
+        context=_context(),
         management_account_id="111111111111",
+        base_session_account_id="222222222222",
         base_session=object(),
         discovered_accounts={
             "111111111111": {
@@ -237,7 +241,39 @@ def test_resolve_accounts_assumes_role_in_management_when_configured():
     accounts = resolver.resolve_accounts()
 
     assert accounts[0].is_management is True
-    assert [account._assume_role for account in accounts] == [True, True]
+    assert [account.access_strategy for account in accounts] == [
+        AccountAccessStrategy.ASSUME_ROLE,
+        AccountAccessStrategy.BASE_SESSION,
+    ]
+
+
+def test_resolve_accounts_uses_base_session_account_direct_for_management_auth():
+    resolver = OrganizationResolver(
+        descriptor=_target(),
+        context=_context(),
+        management_account_id="111111111111",
+        base_session_account_id="111111111111",
+        base_session=object(),
+        discovered_accounts={
+            "111111111111": {
+                "account_number": "111111111111",
+                "account_alias": "management",
+            },
+            "222222222222": {
+                "account_number": "222222222222",
+                "account_alias": "member",
+            },
+        },
+        region_statuses={"us-east-1": "ENABLED_BY_DEFAULT"},
+    )
+
+    accounts = resolver.resolve_accounts()
+
+    assert accounts[0].is_management is True
+    assert [account.access_strategy for account in accounts] == [
+        AccountAccessStrategy.BASE_SESSION,
+        AccountAccessStrategy.ASSUME_ROLE,
+    ]
 
 
 def test_resolve_accounts_expands_all_region_selector():
@@ -245,6 +281,7 @@ def test_resolve_accounts_expands_all_region_selector():
         descriptor=_target(regions=["all"]),
         context=_context(regions=["all"]),
         management_account_id="111111111111",
+        base_session_account_id="111111111111",
         base_session=object(),
         discovered_accounts={
             "111111111111": {
@@ -269,6 +306,7 @@ def test_resolve_accounts_expands_glob_and_explicit_region_selectors(caplog):
         descriptor=_target(regions=["us-*", "ca-central-1"]),
         context=_context(regions=["us-*", "ca-central-1"]),
         management_account_id="111111111111",
+        base_session_account_id="111111111111",
         base_session=object(),
         discovered_accounts={
             "111111111111": {
@@ -296,6 +334,7 @@ def test_resolve_accounts_rejects_glob_matching_no_known_regions():
         descriptor=_target(regions=["moon-*"]),
         context=_context(regions=["moon-*"]),
         management_account_id="111111111111",
+        base_session_account_id="111111111111",
         base_session=object(),
         discovered_accounts={},
         region_statuses={"us-east-1": "ENABLED_BY_DEFAULT"},
@@ -310,6 +349,7 @@ def test_resolve_accounts_raises_when_no_effective_regions_remain():
         descriptor=_target(regions=["us-east-1"]),
         context=_context(regions=["us-east-1"]),
         management_account_id="111111111111",
+        base_session_account_id="111111111111",
         base_session=object(),
         discovered_accounts={},
         region_statuses={"us-west-2": "ENABLED"},
@@ -324,6 +364,7 @@ def test_resolve_accounts_raises_when_selector_matches_only_disabled_regions(cap
         descriptor=_target(regions=["ap-*"]),
         context=_context(regions=["ap-*"]),
         management_account_id="111111111111",
+        base_session_account_id="111111111111",
         base_session=object(),
         discovered_accounts={},
         region_statuses={"ap-south-1": "DISABLED", "us-east-1": "ENABLED"},

--- a/tests/runner/test_organization_resolver.py
+++ b/tests/runner/test_organization_resolver.py
@@ -190,34 +190,6 @@ def test_resolve_accounts_uses_default_management_account_direct_mode():
     assert accounts[1]._regions == ["us-east-1"]
 
 
-def test_resolve_accounts_uses_explicit_management_account_direct_mode():
-    resolver = OrganizationResolver(
-        descriptor=_target(),
-        context=_context(),
-        management_account_id="111111111111",
-        base_session_account_id="111111111111",
-        base_session=object(),
-        discovered_accounts={
-            "111111111111": {
-                "account_number": "111111111111",
-                "account_alias": "management",
-            },
-            "222222222222": {
-                "account_number": "222222222222",
-                "account_alias": "member",
-            },
-        },
-        region_statuses={"us-east-1": "ENABLED_BY_DEFAULT"},
-    )
-
-    accounts = resolver.resolve_accounts()
-
-    assert [account.access_strategy for account in accounts] == [
-        AccountAccessStrategy.BASE_SESSION,
-        AccountAccessStrategy.ASSUME_ROLE,
-    ]
-
-
 def test_resolve_accounts_uses_base_session_account_direct_mode_for_delegated_admin():
     resolver = OrganizationResolver(
         descriptor=_target(),

--- a/tests/runner/test_runner_cancellation_semantics.py
+++ b/tests/runner/test_runner_cancellation_semantics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 
-from anvil.account import Account
+from anvil.account import Account, AccountAccessStrategy
 from anvil.descriptors import ConfigBranch
 from anvil.execution_context import ExecutionContext
 from anvil.executor import execute_accounts
@@ -90,7 +90,7 @@ def test_account_cancelled_before_finishing_is_interrupted():
         account_id="123456789012",
         account_alias="test-account",
         is_management=True,
-        assume_role=False,
+        access_strategy=AccountAccessStrategy.BASE_SESSION,
         base_session=_base_session(),
         context=context,
         regions=["us-east-1"],
@@ -125,7 +125,7 @@ def test_account_success_still_reports_success():
         account_id="123456789012",
         account_alias="test-account",
         is_management=True,
-        assume_role=False,
+        access_strategy=AccountAccessStrategy.BASE_SESSION,
         base_session=_base_session(),
         context=context,
         regions=["us-east-1"],

--- a/tests/runner/test_runner_flow.py
+++ b/tests/runner/test_runner_flow.py
@@ -239,6 +239,110 @@ def test_prepare_target_reuses_same_org_discovery_cache(monkeypatch):
     assert prepared_b.region_statuses == region_statuses
 
 
+def test_prepare_target_keeps_base_session_account_out_of_org_cache(monkeypatch):
+    discovered_accounts = {
+        "111111111111": {"account_number": "111111111111", "account_alias": "payer"},
+        "222222222222": {
+            "account_number": "222222222222",
+            "account_alias": "delegated-admin",
+        },
+    }
+    region_statuses = {"us-east-1": "ENABLED_BY_DEFAULT"}
+    call_counts = {"accounts": 0, "regions": 0}
+    base_account_ids = {
+        "management-profile": "111111111111",
+        "delegated-profile": "222222222222",
+    }
+
+    monkeypatch.setattr(
+        "anvil.runner._run_cached_auth_check_for_target",
+        lambda target, auth_cache: AuthResult(
+            target_name=target.name,
+            status=ExecutionStatus.SUCCESS,
+            source="test",
+            started_at="start",
+            ended_at="end",
+            duration_seconds=0.0,
+            message="ok",
+        ),
+    )
+    monkeypatch.setattr(
+        "anvil.runner.resolve_tasks",
+        lambda task_specs: ResolvedExecution(ordered=[], adjacency={}),
+    )
+
+    class FakeSessionFactory:
+        def create_base_session(self, **kwargs):
+            return type("_BaseSession", (), {"profile_name": kwargs["profile_name"]})()
+
+    monkeypatch.setattr("anvil.runner.SessionFactory", FakeSessionFactory)
+    monkeypatch.setattr(
+        "anvil.runner.OrganizationResolver.describe_organization",
+        staticmethod(lambda session: ("o-shared", "111111111111")),
+    )
+    monkeypatch.setattr(
+        "anvil.runner.OrganizationResolver.describe_base_session_account",
+        staticmethod(lambda session: base_account_ids[session.profile_name]),
+    )
+
+    def fake_discover_accounts(session):
+        call_counts["accounts"] += 1
+        return discovered_accounts
+
+    def fake_discover_regions(session):
+        call_counts["regions"] += 1
+        return region_statuses
+
+    monkeypatch.setattr(
+        "anvil.runner.OrganizationResolver.discover_accounts",
+        staticmethod(fake_discover_accounts),
+    )
+    monkeypatch.setattr(
+        "anvil.runner.OrganizationResolver.discover_region_statuses",
+        staticmethod(fake_discover_regions),
+    )
+
+    organization_cache = OrganizationRunCache()
+    auth_cache = AuthCheckCache()
+
+    prepared_management = prepare_target(
+        index=0,
+        target=TargetDescriptor(
+            config_branch=ConfigBranch.ORGANIZATIONS,
+            name="management-auth",
+            profile="management-profile",
+            tasks=[],
+        ),
+        cli_dry_run=None,
+        cli_include=None,
+        cli_exclude=None,
+        organization_cache=organization_cache,
+        auth_cache=auth_cache,
+    )
+    prepared_delegated = prepare_target(
+        index=1,
+        target=TargetDescriptor(
+            config_branch=ConfigBranch.ORGANIZATIONS,
+            name="delegated-auth",
+            profile="delegated-profile",
+            tasks=[],
+        ),
+        cli_dry_run=None,
+        cli_include=None,
+        cli_exclude=None,
+        organization_cache=organization_cache,
+        auth_cache=auth_cache,
+    )
+
+    assert call_counts == {"accounts": 1, "regions": 1}
+    assert prepared_management.management_account_id == "111111111111"
+    assert prepared_management.base_session_account_id == "111111111111"
+    assert prepared_delegated.management_account_id == "111111111111"
+    assert prepared_delegated.base_session_account_id == "222222222222"
+    assert prepared_management.discovered_accounts == discovered_accounts
+    assert prepared_delegated.discovered_accounts == discovered_accounts
+
+
 def test_prepare_target_uses_bootstrap_region_for_region_selector(monkeypatch):
     created_session_regions: list[str] = []
 

--- a/tests/runner/test_runner_flow.py
+++ b/tests/runner/test_runner_flow.py
@@ -638,5 +638,3 @@ def test_prepare_target_carries_max_parallel_regions_into_context(monkeypatch):
 
     assert prepared.context is not None
     assert prepared.context.max_parallel_regions == 3
-
-

--- a/tests/runner/test_runner_flow.py
+++ b/tests/runner/test_runner_flow.py
@@ -87,6 +87,7 @@ def test_run_multiple_targets_reuses_same_profile_auth_during_preparation(monkey
             object(),
             "o-shared",
             "999999999999",
+            "999999999999",
             {
                 "999999999999": {
                     "account_number": "999999999999",
@@ -170,6 +171,10 @@ def test_prepare_target_reuses_same_org_discovery_cache(monkeypatch):
     monkeypatch.setattr(
         "anvil.runner.OrganizationResolver.describe_organization",
         staticmethod(lambda session: ("o-shared", "999999999999")),
+    )
+    monkeypatch.setattr(
+        "anvil.runner.OrganizationResolver.describe_base_session_account",
+        staticmethod(lambda session: "999999999999"),
     )
 
     def fake_discover_accounts(session):
@@ -263,6 +268,10 @@ def test_prepare_target_uses_bootstrap_region_for_region_selector(monkeypatch):
     monkeypatch.setattr(
         "anvil.runner.OrganizationResolver.describe_organization",
         staticmethod(lambda session: ("o-shared", "999999999999")),
+    )
+    monkeypatch.setattr(
+        "anvil.runner.OrganizationResolver.describe_base_session_account",
+        staticmethod(lambda session: "999999999999"),
     )
     monkeypatch.setattr(
         "anvil.runner.OrganizationResolver.discover_accounts",
@@ -477,6 +486,7 @@ def test_run_prepared_target_uses_cached_org_preflight(monkeypatch):
         base_session=base_session,
         organization_id="o-shared",
         management_account_id="999999999999",
+        base_session_account_id="999999999999",
         discovered_accounts=discovered_accounts,
         region_statuses=region_statuses,
     )
@@ -526,48 +536,3 @@ def test_prepare_target_carries_max_parallel_regions_into_context(monkeypatch):
     assert prepared.context.max_parallel_regions == 3
 
 
-def test_prepare_target_carries_assume_role_in_management_into_context(monkeypatch):
-    monkeypatch.setattr(
-        "anvil.runner._run_cached_auth_check_for_target",
-        lambda target, auth_cache: AuthResult(
-            target_name=target.name,
-            status=ExecutionStatus.SUCCESS,
-            source="test",
-            started_at="start",
-            ended_at="end",
-            duration_seconds=0.0,
-            message="ok",
-        ),
-    )
-    monkeypatch.setattr(
-        "anvil.runner.resolve_tasks",
-        lambda task_specs: ResolvedExecution(ordered=[], adjacency={}),
-    )
-    monkeypatch.setattr(
-        "anvil.runner._preflight_organization",
-        lambda **kwargs: (
-            object(),
-            "o-shared",
-            "999999999999",
-            {},
-            {"us-east-1": "ENABLED_BY_DEFAULT"},
-        ),
-    )
-
-    prepared = prepare_target(
-        index=0,
-        target=TargetDescriptor(
-            config_branch=ConfigBranch.ORGANIZATIONS,
-            name="org-a",
-            assume_role_in_management=True,
-            tasks=[],
-        ),
-        cli_dry_run=None,
-        cli_include=None,
-        cli_exclude=None,
-        organization_cache=OrganizationRunCache(),
-        auth_cache=AuthCheckCache(),
-    )
-
-    assert prepared.context is not None
-    assert prepared.context.assume_role_in_management is True

--- a/tests/tasks/test_task_loader_cache_integration.py
+++ b/tests/tasks/test_task_loader_cache_integration.py
@@ -58,7 +58,14 @@ def test_graph_and_run_paths_behave_the_same_with_cached_resolution(
     monkeypatch.setattr(
         runner,
         "_preflight_organization",
-        lambda **kwargs: (object(), "o-example", "123456789012", {}, ["us-east-1"]),
+        lambda **kwargs: (
+            object(),
+            "o-example",
+            "123456789012",
+            "123456789012",
+            {},
+            ["us-east-1"],
+        ),
     )
 
     observed_tasks: list[list[str]] = []

--- a/tests/validators/test_config_loading.py
+++ b/tests/validators/test_config_loading.py
@@ -142,9 +142,7 @@ def test_validate_config_schema_rejects_assume_role_in_management_for_organizati
         validators.validate_config_schema(
             config={
                 "schema_version": 1,
-                "organizations": [
-                    {"name": "org-a", "assume_role_in_management": True}
-                ],
+                "organizations": [{"name": "org-a", "assume_role_in_management": True}],
             }
         )
 

--- a/tests/validators/test_config_loading.py
+++ b/tests/validators/test_config_loading.py
@@ -53,30 +53,6 @@ def test_load_config_descriptors_reads_max_parallel_regions():
     assert loaded.targets[0].max_parallel_regions == 4
 
 
-def test_load_config_descriptors_defaults_assume_role_in_management_to_false():
-    validators = _import_validators_or_skip()
-
-    loaded = validators.load_config_descriptors(
-        config={"schema_version": 1, "organizations": [{"name": "org-a"}]}
-    )
-
-    assert loaded.targets[0].assume_role_in_management is False
-
-
-def test_load_config_descriptors_reads_assume_role_in_management():
-    validators = _import_validators_or_skip()
-
-    loaded = validators.load_config_descriptors(
-        config={
-            "schema_version": 1,
-            "organizations": [{"name": "org-a", "assume_role_in_management": True}],
-        }
-    )
-
-    assert loaded.targets[0].assume_role_in_management is True
-    assert loaded.targets[0].role_name == "OrganizationAccountAccessRole"
-
-
 def test_load_config_descriptors_reads_post_run_processors():
     validators = _import_validators_or_skip()
 
@@ -159,15 +135,18 @@ def test_validate_config_schema_accepts_max_parallel_regions_for_accounts():
     )
 
 
-def test_validate_config_schema_accepts_assume_role_in_management_for_organizations():
+def test_validate_config_schema_rejects_assume_role_in_management_for_organizations():
     validators = _import_validators_or_skip()
 
-    validators.validate_config_schema(
-        config={
-            "schema_version": 1,
-            "organizations": [{"name": "org-a", "assume_role_in_management": True}],
-        }
-    )
+    with pytest.raises(ValueError, match="assume_role_in_management"):
+        validators.validate_config_schema(
+            config={
+                "schema_version": 1,
+                "organizations": [
+                    {"name": "org-a", "assume_role_in_management": True}
+                ],
+            }
+        )
 
 
 def test_validate_config_schema_rejects_assume_role_in_management_for_accounts():

--- a/tests/validators/test_org_validation.py
+++ b/tests/validators/test_org_validation.py
@@ -40,16 +40,6 @@ def test_accounts_assume_role_mode_allows_multiple_accounts():
     assert descriptor.include == ["111111111111", "222222222222"]
 
 
-def test_accounts_reject_assume_role_in_management():
-    with pytest.raises(ValueError, match="only supported for organizations"):
-        TargetDescriptor(
-            config_branch=ConfigBranch.ACCOUNTS,
-            name="account-group",
-            include=["111111111111"],
-            assume_role_in_management=True,
-        )
-
-
 def test_max_parallel_regions_defaults_to_one():
     descriptor = TargetDescriptor(config_branch=ConfigBranch.ORGANIZATIONS, name="org")
 


### PR DESCRIPTION
Fix organization account access planning when the authenticated base session belongs to a delegated administrator account instead of the AWS Organizations management account.

Anvil now distinguishes:
- management_account_id: the AWS Organizations owner account
- base_session_account_id: the account backing the current authenticated session

The base-session account is executed directly. All other selected organization accounts, including the management/payer account when using delegated-admin auth, use the configured role_name.


## Checklist
- [x] Python format, lint, and tests (`ruff` and `pytest`) were successful.
- [x] Pre-commit hooks passed locally.
- [x] Documentation updated if needed.
- [x] Unit tests added or updated.
