### PR TITLE
feat(container): add official multi-platform image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**
+!.dockerignore
+!Dockerfile
+!LICENSE
+!README.md
+!pyproject.toml
+!uv.lock
+!src/
+!src/**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,18 @@
 
 version: 2
 updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "07:55"
+      timezone: "America/Chicago"
+    commit-message:
+      prefix: "chore(docker)"
+    labels:
+      - "dependencies"
+      - "docker"
+
   - package-ecosystem: "uv"
     directory: "/"
     schedule:

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,334 @@
+name: Container
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build, e.g. v0.32.0; defaults to the selected ref"
+        required: false
+        type: string
+      push:
+        description: "Publish the validated image to GHCR"
+        required: false
+        default: false
+        type: boolean
+      platforms:
+        description: "Comma-separated OCI platforms"
+        required: false
+        default: "linux/amd64,linux/arm64"
+        type: string
+
+  workflow_call:
+    inputs:
+      tag:
+        description: "Git tag to build, e.g. v0.32.0"
+        required: true
+        type: string
+      push:
+        description: "Publish the validated image to GHCR"
+        required: false
+        default: false
+        type: boolean
+      platforms:
+        description: "Comma-separated OCI platforms"
+        required: false
+        default: "linux/amd64,linux/arm64"
+        type: string
+    outputs:
+      digest:
+        description: "Published multi-platform image digest"
+        value: ${{ jobs.publish.outputs.digest }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: container-${{ inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      created: ${{ steps.metadata.outputs.created }}
+      image: ${{ steps.metadata.outputs.image }}
+      platforms: ${{ steps.platforms.outputs.platforms }}
+      revision: ${{ steps.metadata.outputs.revision }}
+      version: ${{ steps.metadata.outputs.version }}
+    steps:
+      - name: Checkout image source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.tag || github.sha }}
+
+      - name: Validate release metadata
+        id: metadata
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_PUSH: ${{ inputs.push }}
+        shell: bash
+        run: |
+          version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          if [[ "$INPUT_PUSH" == "true" && -z "$INPUT_TAG" ]]; then
+            echo "::error::tag is required when push is true"
+            exit 1
+          fi
+          if [[ -n "$INPUT_TAG" && "$INPUT_TAG" != "v${version}" ]]; then
+            echo "::error::tag '${INPUT_TAG}' does not match project version '${version}'"
+            exit 1
+          fi
+
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          revision="$(git rev-parse HEAD)"
+          created="$(git show --no-patch --format=%cI HEAD)"
+          echo "created=$created" >> "$GITHUB_OUTPUT"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "revision=$revision" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate platforms
+        id: platforms
+        env:
+          INPUT_PLATFORMS: ${{ inputs.platforms }}
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+
+          supported = {"linux/amd64", "linux/arm64"}
+          platforms = [
+              platform.strip()
+              for platform in os.environ["INPUT_PLATFORMS"].split(",")
+              if platform.strip()
+          ]
+          if not platforms:
+              raise SystemExit("::error::at least one platform is required")
+          if len(platforms) != len(set(platforms)):
+              raise SystemExit("::error::platforms must not contain duplicates")
+          unsupported = sorted(set(platforms) - supported)
+          if unsupported:
+              raise SystemExit(
+                  "::error::unsupported platform(s): " + ", ".join(unsupported)
+              )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"platforms={json.dumps(platforms, separators=(',', ':'))}\n")
+          PY
+
+  build-smoke:
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJSON(needs.prepare.outputs.platforms) }}
+    steps:
+      - name: Checkout image source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.tag || github.sha }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Log in to GHCR
+        if: inputs.push
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Prepare platform output
+        id: platform
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        shell: bash
+        run: |
+          platform_pair="${PLATFORM//\//-}"
+          echo "artifact=container-digest-${platform_pair}" >> "$GITHUB_OUTPUT"
+          echo "local_tag=anvil-container-smoke:${platform_pair}" >> "$GITHUB_OUTPUT"
+
+      - name: Build platform image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            REVISION=${{ needs.prepare.outputs.revision }}
+            CREATED=${{ needs.prepare.outputs.created }}
+          load: ${{ !inputs.push }}
+          tags: ${{ !inputs.push && steps.platform.outputs.local_tag || '' }}
+          outputs: ${{ inputs.push && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', needs.prepare.outputs.image) || '' }}
+          provenance: ${{ inputs.push && 'mode=max' || false }}
+          sbom: ${{ inputs.push }}
+
+      - name: Select smoke-test image
+        id: smoke-image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ needs.prepare.outputs.image }}
+          LOCAL_TAG: ${{ steps.platform.outputs.local_tag }}
+          PLATFORM: ${{ matrix.platform }}
+          PUSH: ${{ inputs.push }}
+        shell: bash
+        run: |
+          if [[ "$PUSH" == "true" ]]; then
+            reference="${IMAGE}@${DIGEST}"
+            docker pull --platform "$PLATFORM" "$reference"
+          else
+            reference="$LOCAL_TAG"
+          fi
+          echo "reference=$reference" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test image
+        env:
+          IMAGE_REFERENCE: ${{ steps.smoke-image.outputs.reference }}
+          PLATFORM: ${{ matrix.platform }}
+        shell: bash
+        run: |
+          docker run --rm --platform "$PLATFORM" "$IMAGE_REFERENCE" --version
+          docker run --rm --platform "$PLATFORM" "$IMAGE_REFERENCE" list --providers
+          docker run --rm --platform "$PLATFORM" "$IMAGE_REFERENCE" list --tasks
+          docker run --rm --platform "$PLATFORM" "$IMAGE_REFERENCE" list --processors
+          docker run --rm --platform "$PLATFORM" "$IMAGE_REFERENCE" \
+            validate --tasks --processors --providers --quiet
+          docker run --rm --platform "$PLATFORM" --entrypoint python "$IMAGE_REFERENCE" \
+            -c "import azure.identity, boto3, cloudflare, datadog_api_client, google.auth, github, gitlab, pagerduty"
+          docker run --rm --platform "$PLATFORM" --entrypoint python "$IMAGE_REFERENCE" \
+            -c "import os; from pathlib import Path; assert os.geteuid() != 0; path = Path('/workspace/.write-test'); path.write_text('ok'); path.unlink()"
+          docker run --rm --platform "$PLATFORM" \
+            --volume "$GITHUB_WORKSPACE/yaml/noop.yaml:/tmp/anvil.yaml:ro" \
+            "$IMAGE_REFERENCE" validate --config-file /tmp/anvil.yaml --quiet
+
+      - name: Export platform digest
+        if: inputs.push
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        shell: bash
+        run: |
+          mkdir --parents "$RUNNER_TEMP/container-digests"
+          touch "$RUNNER_TEMP/container-digests/${DIGEST#sha256:}"
+
+      - name: Upload platform digest
+        if: inputs.push
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.platform.outputs.artifact }}
+          path: ${{ runner.temp }}/container-digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    if: inputs.push
+    needs:
+      - prepare
+      - build-smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.published.outputs.digest }}
+    steps:
+      - name: Download platform digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: container-digest-*
+          path: ${{ runner.temp }}/container-digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Generate image tags
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ needs.prepare.outputs.image }}
+          flavor: latest=auto
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}},value=${{ inputs.tag }},enable=${{ !startsWith(needs.prepare.outputs.version, '0.') }}
+
+      - name: Publish multi-platform image
+        id: published
+        env:
+          DIGEST_DIRECTORY: ${{ runner.temp }}/container-digests
+          IMAGE: ${{ needs.prepare.outputs.image }}
+          TAGS_JSON: ${{ steps.metadata.outputs.json }}
+        shell: bash
+        run: |
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$TAGS_JSON")
+          tag_arguments=()
+          for tag in "${tags[@]}"; do
+            tag_arguments+=(--tag "$tag")
+          done
+
+          digest_sources=()
+          while IFS= read -r digest_file; do
+            digest_sources+=("${IMAGE}@sha256:$(basename "$digest_file")")
+          done < <(find "$DIGEST_DIRECTORY" -type f -print | sort)
+
+          if [[ ${#digest_sources[@]} -eq 0 ]]; then
+            echo "::error::no validated platform digests were downloaded"
+            exit 1
+          fi
+
+          docker buildx imagetools create "${tag_arguments[@]}" "${digest_sources[@]}"
+          primary_tag="${tags[0]}"
+          digest="$(docker buildx imagetools inspect "$primary_tag" | awk '/^Digest:/ {print $2; exit}')"
+          if [[ -z "$digest" ]]; then
+            echo "::error::could not resolve published image digest"
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "Published ${primary_tag}@${digest}"
+
+      - name: Verify public image access
+        env:
+          DIGEST: ${{ steps.published.outputs.digest }}
+          IMAGE: ${{ needs.prepare.outputs.image }}
+        shell: bash
+        run: |
+          docker logout ghcr.io
+          docker buildx imagetools inspect "${IMAGE}@${DIGEST}" > /dev/null
+
+      - name: Publish summary
+        env:
+          DIGEST: ${{ steps.published.outputs.digest }}
+          IMAGE: ${{ needs.prepare.outputs.image }}
+          TAGS: ${{ steps.metadata.outputs.tags }}
+        shell: bash
+        run: |
+          {
+            echo "## Container image"
+            echo
+            echo "Digest: \`${IMAGE}@${DIGEST}\`"
+            echo
+            echo "Tags:"
+            while IFS= read -r tag; do
+              echo "- \`${tag}\`"
+            done <<< "$TAGS"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,10 +1,6 @@
 name: "Publish"
 
 on:
-  push:
-    tags:
-      - v*
-
   workflow_dispatch:
     inputs:
       tag:
@@ -32,6 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,3 +88,15 @@ jobs:
     uses: ./.github/workflows/publish.yaml
     with:
       tag: ${{ needs.tag-release.outputs.tag }}
+
+  publish-container:
+    needs: tag-release
+    if: needs.tag-release.outputs.released == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/container.yaml
+    with:
+      tag: ${{ needs.tag-release.outputs.tag }}
+      push: true
+      platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1.7
+
+FROM python:3.14-slim@sha256:ce40764625a4ff50df3548277632e7f96c4e77fe75fa848aae9885476e7df5a4 AS python-base
+
+FROM ghcr.io/astral-sh/uv:0.10.0@sha256:78a7ff97cd27b7124a5f3c2aefe146170793c56a1e03321dd31a289f6d82a04f AS uv
+
+FROM python-base AS builder
+
+COPY --from=uv /uv /usr/local/bin/uv
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
+
+WORKDIR /opt/anvil
+
+COPY pyproject.toml uv.lock README.md LICENSE ./
+COPY src ./src
+
+RUN uv sync --locked --no-dev --extra all --no-editable
+
+FROM python-base AS runtime
+
+ARG VERSION=unknown
+ARG REVISION=unknown
+ARG CREATED=unknown
+
+LABEL org.opencontainers.image.title="Anvil" \
+      org.opencontainers.image.description="Provider-aware cloud task runner" \
+      org.opencontainers.image.source="https://github.com/JSChronicles/anvil" \
+      org.opencontainers.image.url="https://github.com/JSChronicles/anvil" \
+      org.opencontainers.image.documentation="https://opsfoundry.dev/anvil/" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}"
+
+RUN groupadd --gid 10001 anvil \
+    && useradd --uid 10001 --gid anvil --create-home --shell /usr/sbin/nologin anvil \
+    && mkdir --parents /opt/anvil /workspace \
+    && chown anvil:anvil /workspace
+
+COPY --from=builder /opt/anvil/.venv /opt/anvil/.venv
+
+ENV HOME=/home/anvil \
+    PATH=/opt/anvil/.venv/bin:$PATH \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+USER anvil
+WORKDIR /workspace
+
+ENTRYPOINT ["anvil"]

--- a/README.md
+++ b/README.md
@@ -107,11 +107,48 @@ Anvil is built for teams that need repeatable cloud workflows, such as inventory
 
 There are multiple global commands:
 ```console
+anvil --version  # Print the installed Anvil version
 anvil list      # List available tasks, processors, and providers
 anvil validate  # Inspect environment health or run focused validation checks
 anvil run       # Execute YAML-defined workflows
 anvil results   # Query JSONL results and rerun failures
 ```
+
+### Container image
+
+The official batteries-included OCI image is published publicly to GitHub
+Container Registry with every first-party provider dependency installed. It
+uses the existing Anvil CLI directly and does not include cloud CLIs, Terraform,
+kubectl, or other unrelated operator tooling.
+
+Run a specific release locally with Docker or Podman:
+
+```console
+docker run --rm ghcr.io/jschronicles/anvil:<version> --version
+```
+
+Mount the working directory to make configuration available and retain results:
+
+```console
+docker run --rm \
+  --volume "$PWD:/workspace" \
+  ghcr.io/jschronicles/anvil:<version> \
+  run --config-file /workspace/anvil.yaml
+```
+
+Anvil writes run output beneath `/workspace/results`. The mounted directory must
+be writable by the image's non-root user (UID and GID `10001`). Supply cloud and
+service credentials at runtime through environment variables, workload identity,
+managed identity, or read-only credential mounts; never add credentials to an
+image. Provider profiles can be mounted at `/home/anvil/.anvil/config.toml` or
+selected with `ANVIL_CONFIG`.
+
+Stable releases publish exact and minor tags plus `latest`. Starting with Anvil
+1.0, releases also publish a major tag. Prereleases publish only their exact tag.
+For reproducible deployments, pin the image digest reported by GHCR.
+The publication workflow verifies anonymous access; repository administrators
+must set the GHCR package visibility to public if it does not inherit the public
+repository visibility on its first publication.
 
 Example AWS task configuration:
 

--- a/src/anvil/cli.py
+++ b/src/anvil/cli.py
@@ -735,8 +735,12 @@ def _diagnostic_dependency_checks() -> list[DiagnosticCheck]:
     dependencies = [
         ("aws", "boto3", "boto3"),
         ("azure", "azure.identity", "azure-identity"),
+        ("cloudflare", "cloudflare", "cloudflare"),
+        ("datadog", "datadog_api_client", "datadog-api-client"),
         ("gcp", "google.auth", "google-auth"),
         ("github", "github", "PyGithub"),
+        ("gitlab", "gitlab", "python-gitlab"),
+        ("pagerduty", "pagerduty", "pagerduty"),
     ]
 
     checks: list[DiagnosticCheck] = []

--- a/tests/cli/test_validate_diagnostics.py
+++ b/tests/cli/test_validate_diagnostics.py
@@ -123,7 +123,11 @@ def test_diagnostic_dependency_checks_report_importable_and_missing(monkeypatch)
     assert by_label["aws"].status == "OK"
     assert by_label["github"].status == "OK"
     assert by_label["azure"].status == "WARN"
+    assert by_label["cloudflare"].status == "WARN"
+    assert by_label["datadog"].status == "WARN"
     assert by_label["gcp"].status == "WARN"
+    assert by_label["gitlab"].status == "WARN"
+    assert by_label["pagerduty"].status == "WARN"
 
 
 def test_module_available_treats_missing_parent_package_as_unavailable(monkeypatch):


### PR DESCRIPTION
## Description
Add a batteries-included Anvil container image based on Python 3.14 slim with all supported provider dependencies installed from package metadata.

- Add an official batteries-included Anvil OCI image
- Use Python 3.14 slim with pinned base-image digests
- Install all official provider dependencies through the existing `all` extra
- Run as a non-root user with `anvil` as the entrypoint
- Support `linux/amd64` and `linux/arm64`
- Add a reusable and manually dispatchable container workflow
- Smoke-test each platform before creating release tags
- Publish versioned images to GHCR with SBOM and provenance
- Prevent prereleases from replacing the stable `latest` tag
- Verify that published images are publicly accessible
- Integrate container publication with the existing release workflow
- Document local, CI, authentication, mount, and digest-pinned usage
- Add Dependabot coverage for pinned Docker base images
- Extend diagnostics for all supported provider SDKs


## Checklist
- [x] Python format, lint, and tests (`ruff` and `pytest`) were successful.
- [x] Pre-commit hooks passed locally.
- [x] Documentation updated if needed.
- [x] Unit tests added or updated.
