### PR TITLE
Chore/consolidation

### DIFF
--- a/.agents/skills/anvil-task-builder/SKILL.md
+++ b/.agents/skills/anvil-task-builder/SKILL.md
@@ -3,7 +3,7 @@ name: anvil-task-builder
 description: Builds and maintains Anvil task modules, workflows, schemas, runner behavior, SARIF-compatible detect_ tasks, and plugin templates. Use when user asks to "create an Anvil task", "edit this task", "add dry-run behavior", "record actions", "return task results", "create a SARIF task", "create a detect task", "update Anvil YAML", "modify schemas", "change account execution", "update plugin templates", "add concurrency for the payer account", or "build a management-account-only task".
 metadata:
   author: JSChronicles
-  version: "0.10"
+  version: "0.11"
 ---
 
 # Anvil Task Builder

--- a/.agents/skills/anvil-task-builder/SKILL.md
+++ b/.agents/skills/anvil-task-builder/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: anvil-task-builder
-description: Builds and maintains Anvil task modules, workflows, schemas, runner behavior, SARIF-compatible detect_ tasks, and plugin templates. Use when user asks to "create an Anvil task", "edit this task", "add dry-run behavior", "record actions", "return task results", "create a SARIF task", "create a detect task", "update Anvil YAML", "modify schemas", "change account execution", "update plugin templates", "add concurrency for the payer account", or "build a management-account-only task".
+description: Builds and maintains Anvil task modules, workflows, schemas, runner behavior, SARIF-compatible detect_ tasks, and plugin templates. Use when user asks to create or edit an Anvil task, choose or change task scope, fix repeated regional execution, add dry-run behavior, record actions, return task results, update Anvil YAML or schemas, change account execution, update plugin templates, add payer-account concurrency, or build a management-account-only task.
 metadata:
   author: JSChronicles
-  version: "0.11"
+  version: "0.12"
 ---
 
 # Anvil Task Builder
@@ -13,13 +13,14 @@ Use this skill to create Anvil tasks that satisfy the runtime contract, behave s
 ## Workflow
 
 1. Decide whether the task is a stock task or plugin task.
-2. Create or edit the task module.
-3. Implement the Anvil `run()` contract.
-4. Add useful Google-style docstrings, especially on `run()`, so `anvil list --tasks <task_name> --detail` explains the task.
-5. Follow Anvil task conventions for dry-run behavior, logging, actions, and returned data.
-6. Apply normal Python and provider-specific implementation hygiene.
-7. Add or update YAML examples that reference the task when useful.
-8. Run `uv run anvil validate --tasks`.
+2. Determine the provider resource ownership boundary and choose the task scope.
+3. Create or edit the task module.
+4. Implement the Anvil `run()` contract.
+5. Add useful Google-style docstrings, especially on `run()`, so `anvil list --tasks <task_name> --detail` explains the task.
+6. Follow Anvil task conventions for dry-run behavior, logging, actions, and returned data.
+7. Apply normal Python and provider-specific implementation hygiene.
+8. Add or update YAML examples that reference the task when useful.
+9. Run `uv run anvil validate --tasks`.
 
 ## Core Rules
 
@@ -50,6 +51,16 @@ Use this skill to create Anvil tasks that satisfy the runtime contract, behave s
   per provider with `create_provider_instance()`. Do not use legacy generic
   plugin or per-component entry points.
 - Every task module must define a callable keyword-only `run()` function.
+- Choose scope from the provider resource ownership boundary, not as a
+  performance setting. Omit `TASK_SCOPE` only when one invocation per resolved
+  target and location is correct; otherwise declare a provider-supported scope.
+- Use `target` for resources independently owned by each resolved execution
+  target and `configured_target` only when work belongs to the original
+  configured target or its shared control plane. Split a module that combines
+  resources requiring different scopes.
+- Treat scope as a safety decision for destructive tasks. An account-wide or
+  provider-global mutation left at default region scope can execute repeatedly
+  for the same target.
 - Every task `run()` function must have a useful Google-style docstring. Include a short summary plus `Args:`, `Returns:`, and `Raises:` sections when applicable; document required `metadata` keys explicitly.
 - The provided `session` is already scoped to the provider target and region.
 - Check `dry_run` before every mutating API call.
@@ -67,6 +78,7 @@ Use this skill to create Anvil tasks that satisfy the runtime contract, behave s
 Load only the reference files needed for the current task:
 
 - For stock task, plugin task, entry-point, and `run()` signature rules, read `references/runtime-contract.md`.
+- For choosing, changing, documenting, or reviewing task scope, read `references/task-scopes.md`.
 - For dry-run behavior, action recording, logging, and result shape, read `references/dry-run-and-actions.md`.
 - For task granularity, inventory task boundaries, performance, and region concurrency, read `references/task-granularity.md`.
 - For concurrency guidance specific to workflows that target only the payer/management account, read `references/payer-management-account-tasks.md`.
@@ -77,6 +89,11 @@ Load only the reference files needed for the current task:
 
 ## Review Behavior
 
-When reviewing Anvil tasks, prioritize runtime contract violations, missing or weak `run()` docstrings for `--detail`, missing dry-run guards, unsafe provider mutation behavior, invalid metadata handling, missing task discovery wiring, and validation gaps.
+When reviewing Anvil tasks, prioritize incorrect scope or repeated global work,
+runtime contract violations, missing or weak `run()` docstrings for `--detail`,
+missing dry-run guards, unsafe provider mutation behavior, invalid metadata
+handling, missing task discovery wiring, and validation gaps. Verify scope
+against the API's ownership boundary even when the declared scope passes
+validation; Anvil cannot infer that semantic choice.
 
 If no issues are found, say so directly and mention any commands that were not run.

--- a/.agents/skills/anvil-task-builder/references/github-task-patterns.md
+++ b/.agents/skills/anvil-task-builder/references/github-task-patterns.md
@@ -17,14 +17,16 @@ Repository-only tasks should validate and split `execution_target_id` with
 
 ## REST Helpers
 
-Use helpers from `anvil.providers.github.tasks._rest` instead of reaching into
+Use metadata validators from `anvil.providers.tasks._task_helpers` and REST
+helpers from `anvil.providers.github.tasks._rest` instead of reaching into
 PyGithub directly when a REST endpoint is needed:
 
 - `require_github_provider(...)` validates provider compatibility.
 - `require_repository_target(...)` validates repository targets and returns
   `(owner, repo)`.
-- `metadata_bool(...)`, `metadata_int(...)`, `metadata_string(...)`, and
-  `metadata_params(...)` validate YAML metadata.
+- `metadata_bool(...)`, `metadata_int(...)`, and `metadata_string(...)` validate
+  scalar YAML metadata consistently across providers.
+- `metadata_params(...)` validates GitHub REST query parameters.
 - `rest_get(...)` performs a single REST GET through the runtime session client.
 - `list_rest_items(...)` handles paginated REST list endpoints with
   `max_results`.

--- a/.agents/skills/anvil-task-builder/references/payer-management-account-tasks.md
+++ b/.agents/skills/anvil-task-builder/references/payer-management-account-tasks.md
@@ -6,6 +6,11 @@ several targets in a broader multi-account run. If the same workflow also
 targets other accounts, treat the payer account like any other target and
 follow the general guidance in `task-granularity.md` instead.
 
+Choose task scope before applying this concurrency guidance. Payer-only target
+selection does not itself imply `configured_target`. Use that scope only when
+the operation belongs to the original configured target or its shared control
+plane, following `task-scopes.md`.
+
 ## Why This Case Is Different
 
 `task-granularity.md` frames concurrency pressure as:

--- a/.agents/skills/anvil-task-builder/references/runtime-contract.md
+++ b/.agents/skills/anvil-task-builder/references/runtime-contract.md
@@ -92,7 +92,7 @@ Runtime facts:
   `TASK_SCOPE = "configured_target"` to run once for the configured YAML target.
 - Providers declare which task scopes they support. Read
   `ProviderMetadata.supported_task_scopes` instead of maintaining a provider
-  allowlist. Stock AWS currently supports `configured_target` and `region`;
+  allowlist. Stock AWS currently supports `configured_target`, `target`, and `region`;
   the other stock providers currently support `region` and `target`.
 - A target-scoped task receives the first resolved concrete provider location
   as `region`, and its session uses that location. No synthetic target-scope or

--- a/.agents/skills/anvil-task-builder/references/task-granularity.md
+++ b/.agents/skills/anvil-task-builder/references/task-granularity.md
@@ -4,6 +4,7 @@ Before creating or splitting inventory tasks, consider whether related data shou
 
 Prefer separate tasks when:
 
+- The resources have different task scopes or ownership boundaries.
 - The tasks have different safety profiles, especially read-only vs mutating.
 - They are commonly run independently.
 - They need different failure, cleanup, or dependency behavior.
@@ -12,6 +13,7 @@ Prefer separate tasks when:
 
 Consider one combined inventory task when:
 
+- The resources share the same task scope and ownership boundary.
 - The tasks are read-only.
 - They query the same AWS service in the same account-region.
 - They repeat the same list or describe operations.

--- a/.agents/skills/anvil-task-builder/references/task-scopes.md
+++ b/.agents/skills/anvil-task-builder/references/task-scopes.md
@@ -1,0 +1,93 @@
+# Task Scope Selection
+
+Use this reference whenever a task is created, changes the provider resources
+it touches, changes scope, or is reviewed for duplicate execution.
+
+Task scope defines invocation count and result ownership. It is a correctness
+and safety contract, not a concurrency or performance knob. Declare it in the
+Python module; task YAML does not select scope.
+
+## Decision Sequence
+
+Ask these questions in order:
+
+1. Can the resource state, API result, or action differ by resolved provider
+   location? Use the default `region` scope.
+2. Is the resource global to a target but independently owned by every resolved
+   execution target? Use `TASK_SCOPE = "target"`.
+3. Does the work belong to the original configured target or a shared AWS
+   owner/control plane instead of every execution target discovered beneath it?
+   Use `TASK_SCOPE = "configured_target"`.
+4. Does one module touch resources with different answers? Split it into tasks
+   with one ownership boundary each.
+
+Do not choose a broader scope merely to reduce API calls. If repeated work is
+the problem but ownership is unchanged, improve pagination, caching, shared
+helpers, or task granularity instead.
+
+## Scope Semantics
+
+| Scope | Invocation boundary | Representative resources |
+| --- | --- | --- |
+| `region` | Once per resolved execution target and concrete location | AWS VPCs, subnets, Lambda functions |
+| `target` | Once per resolved execution target | AWS IAM users and policies, Azure resource groups |
+| `configured_target` | Once for the original configured YAML target | AWS Organizations and IAM Identity Center control-plane work |
+
+No `TASK_SCOPE` declaration means `region`.
+
+A target-scoped task still receives `region` and a session using the target's
+first resolved concrete location. This does not make the provider resource
+regional. The task docstring should say whether that location selects an SDK
+endpoint, is passed to an API filter, or is ignored by a target-global API.
+
+`configured_target` changes ownership and dependency mapping. It is appropriate
+only when one configured target may expand into several execution targets but
+the operation must remain attached to the original configuration. It is not a
+generic synonym for management account, payer account, or run once.
+
+## Provider Support
+
+Read `ProviderMetadata.supported_task_scopes` for the selected provider rather
+than maintaining an allowlist in task code. Stock AWS supports `region`,
+`target`, and `configured_target`; the other stock providers currently support
+`region` and `target`.
+
+## Safety and Consolidation
+
+For destructive tasks, explicitly verify the expected invocation count for a
+configuration with multiple targets and locations. A target-global mutation
+left at region scope can be attempted once per configured location.
+
+Consolidate operations only when they share the same ownership boundary as well
+as compatible safety, failure, and result semantics. For example, AWS IAM and
+IAM Identity Center policies require separate tasks: IAM is account-wide per
+resolved target, while Identity Center belongs to a configured-target control
+plane.
+
+## Changing an Existing Scope
+
+A scope change can alter:
+
+- invocation count and which target owns each result;
+- the `region` and session used by the task;
+- dependency fan-out and fan-in shapes;
+- retries, actions, and partial-failure behavior;
+- whether downstream selectors receive one object or a list.
+
+Review workflows, examples, documentation, and tests that consume the task.
+Do not add backward-compatibility behavior unless the user requests it or the
+project contract requires it.
+
+## Validation Checklist
+
+- Confirm the provider API's documented ownership boundary.
+- Count expected invocations for multiple targets and locations.
+- Confirm the provider advertises the declared scope.
+- Test destructive tasks cannot repeat against the same global resource.
+- Test dependency mapping when connected tasks use different scopes.
+- Document scope assumptions and `region` behavior in `run()`.
+- Run `uv run anvil validate --tasks` and focused task or runner tests.
+
+Validation can reject unknown or provider-incompatible declarations. It cannot
+infer whether the API itself is regional, target-global, or owned by a shared
+control plane; review and tests must establish that semantic correctness.

--- a/src/anvil/cli.py
+++ b/src/anvil/cli.py
@@ -26,6 +26,7 @@ import yaml
 from anvil._components import DiscoveryIssue as DiscoveryIssue
 from anvil.benchmark import BenchmarkRecorder
 from anvil.descriptors import LoadedConfig
+from anvil.filename_utils import safe_filename_component
 from anvil.processor_loader import (
     ProcessorDescriptor,
     ProcessorSpec,
@@ -199,16 +200,8 @@ def _create_results_run_dir(*, config_file: Path) -> Path:
     return run_dir
 
 
-def _safe_result_filename(name: str) -> str:
-    safe_name = "".join(
-        character if character.isalnum() or character in {".", "-", "_"} else "_"
-        for character in name
-    )
-    return safe_name.strip("._") or "target"
-
-
 def _target_result_file_path(*, target_results_dir: Path, target_name: str) -> Path:
-    safe_name = _safe_result_filename(target_name)
+    safe_name = safe_filename_component(target_name)
     result_file = target_results_dir / f"{safe_name}.json"
     suffix = 1
 

--- a/src/anvil/cli.py
+++ b/src/anvil/cli.py
@@ -112,7 +112,8 @@ class ListableDescriptor(Protocol):
 class DetailDescriptor(ListableDescriptor, Protocol):
     """Descriptor fields needed for CLI detail output."""
 
-    load: Callable[[], Callable]
+    @property
+    def load(self) -> Callable[[], Callable]: ...
 
 
 class DiscoveryIssueDescriptor(Protocol):

--- a/src/anvil/filename_utils.py
+++ b/src/anvil/filename_utils.py
@@ -1,0 +1,19 @@
+"""Shared helpers for filesystem-safe filename components."""
+
+
+def safe_filename_component(name: str) -> str:
+    """Return a sanitized filename component using Anvil's canonical rules.
+
+    Args:
+        name: Untrusted or provider-derived filename component.
+    Returns:
+        A filename component containing only alphanumeric characters, periods,
+        hyphens, and underscores, without leading or trailing periods or
+        underscores.
+    """
+
+    safe_name = "".join(
+        character if character.isalnum() or character in {".", "-", "_"} else "_"
+        for character in name
+    )
+    return safe_name.strip("._") or "target"

--- a/src/anvil/processor_loader.py
+++ b/src/anvil/processor_loader.py
@@ -21,6 +21,7 @@ from anvil._components import (
     source_from_entry_point,
 )
 from anvil.descriptors import TargetDescriptor
+from anvil.filename_utils import safe_filename_component
 from anvil.results import TargetResult
 
 __LOGGER__ = logging.getLogger(__name__)
@@ -159,14 +160,6 @@ def _parse_processor_specs(
     return specs
 
 
-def _safe_output_filename(name: str) -> str:
-    safe_name = "".join(
-        character if character.isalnum() or character in {".", "-", "_"} else "_"
-        for character in name
-    )
-    return safe_name.strip("._") or "target"
-
-
 def _output_path_parts(output: str) -> list[str]:
     output_path = Path(output)
     parts = [
@@ -214,12 +207,12 @@ def resolve_processor_output_path(
         output_name = parts[-1]
         output_dirs = parts[:-1]
 
-    safe_output_name = _safe_output_filename(output_name)
+    safe_output_name = safe_filename_component(output_name)
     if target_name is not None:
-        safe_output_name = f"{_safe_output_filename(target_name)}-{safe_output_name}"
+        safe_output_name = f"{safe_filename_component(target_name)}-{safe_output_name}"
 
     output_path = reports_dir.joinpath(
-        *(_safe_output_filename(part) for part in output_dirs), safe_output_name
+        *(safe_filename_component(part) for part in output_dirs), safe_output_name
     )
     return _available_output_path(
         output_path=output_path, reserved_paths=reserved_paths

--- a/src/anvil/providers/aws/provider.py
+++ b/src/anvil/providers/aws/provider.py
@@ -155,7 +155,7 @@ class AwsProvider:
         display_name="AWS",
         description="Amazon Web Services provider",
         default_regions=DEFAULT_REGIONS,
-        supported_task_scopes=frozenset({"configured_target", "region"}),
+        supported_task_scopes=frozenset({"configured_target", "target", "region"}),
     )
 
     def __init__(self, *, region_service: AwsRegionService | None = None) -> None:

--- a/src/anvil/providers/aws/tasks/compare_asg_to_cluster_instances.py
+++ b/src/anvil/providers/aws/tasks/compare_asg_to_cluster_instances.py
@@ -39,7 +39,7 @@ def run(
     metadata: dict[str, object],
     dependency_data: dict[str, object],
     actions: ActionRecorder,
-) -> None:
+) -> dict[str, object]:
     """Compare ECS container instances to corresponding Auto Scaling Groups.
 
     For each configured ECS cluster, the task compares EC2 instance IDs
@@ -88,6 +88,7 @@ def run(
 
     autoscaling_client = session.client("autoscaling", region_name=ecs_region)
     ecs_client = session.client("ecs", region_name=ecs_region)
+    cluster_results: list[dict[str, object]] = []
 
     for cluster in cluster_names:
         __LOGGER__.debug(
@@ -126,23 +127,31 @@ def run(
         if container_instances:
             __LOGGER__.debug(f"Gathering ec2InstanceIds for cluster '{cluster}'")
 
-            ecs_instance_ids = {
-                container_instance["ec2InstanceId"]
-                for container_instance in container_instances
-            }
+            ecs_instance_ids: set[str] = set()
 
             __LOGGER__.debug(
                 f"Initializing list for instances with 0 running tasks "
                 f"in cluster '{cluster}'"
             )
 
-            instances_with_zero_tasks: list[str] = []
+            instances_with_zero_tasks: set[str] = set()
 
             for container_instance in container_instances:
-                if container_instance["runningTasksCount"] == 0:
-                    instances_with_zero_tasks.append(
-                        container_instance["ec2InstanceId"]
+                instance_id = container_instance.get("ec2InstanceId")
+                running_task_count = container_instance.get("runningTasksCount")
+                if not isinstance(instance_id, str):
+                    raise RuntimeError(
+                        "ECS describe_container_instances returned a container "
+                        "instance without a string ec2InstanceId"
                     )
+                if not isinstance(running_task_count, int):
+                    raise RuntimeError(
+                        "ECS describe_container_instances returned a container "
+                        "instance without an integer runningTasksCount"
+                    )
+                ecs_instance_ids.add(instance_id)
+                if running_task_count == 0:
+                    instances_with_zero_tasks.add(instance_id)
 
             diff_instance_ids = ecs_instance_ids - asg_instance_ids
 
@@ -158,12 +167,46 @@ def run(
                     f"All ECS instances in cluster '{cluster}' "
                     f"are part of the ASG '{cluster}-asg'."
                 )
-                __LOGGER__.info(
-                    f"ECS instances with 0 running tasks "
-                    f"in cluster '{cluster}': {instances_with_zero_tasks}"
-                )
+            __LOGGER__.info(
+                f"ECS instances with 0 running tasks "
+                f"in cluster '{cluster}': {instances_with_zero_tasks}"
+            )
+            cluster_results.append(
+                {
+                    "cluster": cluster,
+                    "asg_name": f"{cluster}-asg",
+                    "ecs_instance_ids": sorted(ecs_instance_ids),
+                    "asg_instance_ids": sorted(asg_instance_ids),
+                    "instances_missing_from_asg": sorted(diff_instance_ids),
+                    "instances_with_zero_tasks": sorted(instances_with_zero_tasks),
+                }
+            )
 
         else:
             __LOGGER__.info(f"No container instances found in cluster '{cluster}'.")
+            cluster_results.append(
+                {
+                    "cluster": cluster,
+                    "asg_name": f"{cluster}-asg",
+                    "ecs_instance_ids": [],
+                    "asg_instance_ids": sorted(asg_instance_ids),
+                    "instances_missing_from_asg": [],
+                    "instances_with_zero_tasks": [],
+                }
+            )
 
     actions.record(f"Completed ASG vs ECS comparison for {len(cluster_names)} clusters")
+    return {
+        "cluster_count": len(cluster_results),
+        "clusters": cluster_results,
+        "missing_from_asg_count": sum(
+            len(result["instances_missing_from_asg"])
+            for result in cluster_results
+            if isinstance(result["instances_missing_from_asg"], list)
+        ),
+        "zero_task_instance_count": sum(
+            len(result["instances_with_zero_tasks"])
+            for result in cluster_results
+            if isinstance(result["instances_with_zero_tasks"], list)
+        ),
+    }

--- a/src/anvil/providers/aws/tasks/get_aws_inline_policies.py
+++ b/src/anvil/providers/aws/tasks/get_aws_inline_policies.py
@@ -1,192 +1,170 @@
 from __future__ import annotations
 
-import json
 import logging
-from typing import Any
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 
 import boto3
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 
 from anvil.actions import ActionRecorder
+from anvil.task_errors import TaskExecutionError
 
 __LOGGER__ = logging.getLogger(__name__)
-
-SUPPORTED_POLICY_TYPES: set[str] = {"user", "role", "group", "sso"}
-
-
-def _list_user_policies(iam_client: BaseClient) -> list[dict[str, Any]]:
-    policies: list[dict[str, Any]] = []
-
-    user_paginator = iam_client.get_paginator("list_users")
-
-    for user_page in user_paginator.paginate():
-        for user_entry in user_page.get("Users", []):
-            username = user_entry["UserName"]
-
-            policy_paginator = iam_client.get_paginator("list_user_policies")
-
-            for policy_page in policy_paginator.paginate(UserName=username):
-                for policy_name in policy_page.get("PolicyNames", []):
-                    try:
-                        policy_response = iam_client.get_user_policy(
-                            UserName=username, PolicyName=policy_name
-                        )
-
-                        policies.append(
-                            {
-                                "EntityType": "User",
-                                "EntityName": username,
-                                "PolicyType": "Inline",
-                                "PolicyName": policy_name,
-                                "PolicyDocument": policy_response["PolicyDocument"],
-                            }
-                        )
-
-                    except ClientError as error:
-                        __LOGGER__.warning(
-                            f"Failed to fetch inline policy '{policy_name}' "
-                            f"for user '{username}': {error}"
-                        )
-
-    return policies
+TASK_SCOPE = "target"
+MAX_IAM_WORKERS = 5
 
 
-def _list_role_policies(iam_client: BaseClient) -> list[dict[str, Any]]:
-    policies: list[dict[str, Any]] = []
+@dataclass(frozen=True, slots=True)
+class _IamPolicyResource:
+    """Describe one IAM inline-policy resource API family."""
 
-    role_paginator = iam_client.get_paginator("list_roles")
-
-    for role_page in role_paginator.paginate():
-        for role_entry in role_page.get("Roles", []):
-            role_name = role_entry["RoleName"]
-
-            policy_paginator = iam_client.get_paginator("list_role_policies")
-
-            for policy_page in policy_paginator.paginate(RoleName=role_name):
-                for policy_name in policy_page.get("PolicyNames", []):
-                    try:
-                        policy_response = iam_client.get_role_policy(
-                            RoleName=role_name, PolicyName=policy_name
-                        )
-
-                        policies.append(
-                            {
-                                "EntityType": "Role",
-                                "EntityName": role_name,
-                                "PolicyType": "Inline",
-                                "PolicyName": policy_name,
-                                "PolicyDocument": policy_response["PolicyDocument"],
-                            }
-                        )
-
-                    except ClientError as error:
-                        __LOGGER__.warning(
-                            f"Failed to fetch inline policy '{policy_name}' "
-                            f"for role '{role_name}': {error}"
-                        )
-
-    return policies
+    selector: str
+    result_key: str
+    list_operation: str
+    list_result_key: str
+    name_key: str
+    list_policy_operation: str
+    get_policy_operation: str
 
 
-def _list_group_policies(iam_client: BaseClient) -> list[dict[str, Any]]:
-    policies: list[dict[str, Any]] = []
-
-    group_paginator = iam_client.get_paginator("list_groups")
-
-    for group_page in group_paginator.paginate():
-        for group_entry in group_page.get("Groups", []):
-            group_name = group_entry["GroupName"]
-
-            policy_paginator = iam_client.get_paginator("list_group_policies")
-
-            for policy_page in policy_paginator.paginate(GroupName=group_name):
-                for policy_name in policy_page.get("PolicyNames", []):
-                    try:
-                        policy_response = iam_client.get_group_policy(
-                            GroupName=group_name, PolicyName=policy_name
-                        )
-
-                        policies.append(
-                            {
-                                "EntityType": "Group",
-                                "EntityName": group_name,
-                                "PolicyType": "Inline",
-                                "PolicyName": policy_name,
-                                "PolicyDocument": policy_response["PolicyDocument"],
-                            }
-                        )
-
-                    except ClientError as error:
-                        __LOGGER__.warning(
-                            f"Failed to fetch inline policy '{policy_name}' "
-                            f"for group '{group_name}': {error}"
-                        )
-
-    return policies
+RESOURCE_SPECS = {
+    spec.selector: spec
+    for spec in (
+        _IamPolicyResource(
+            "user",
+            "User",
+            "list_users",
+            "Users",
+            "UserName",
+            "list_user_policies",
+            "get_user_policy",
+        ),
+        _IamPolicyResource(
+            "role",
+            "Role",
+            "list_roles",
+            "Roles",
+            "RoleName",
+            "list_role_policies",
+            "get_role_policy",
+        ),
+        _IamPolicyResource(
+            "group",
+            "Group",
+            "list_groups",
+            "Groups",
+            "GroupName",
+            "list_group_policies",
+            "get_group_policy",
+        ),
+    )
+}
 
 
-# SSO Inline Policy Collector (Management Account Only)
-def _list_sso_policies(session: boto3.Session) -> list[dict[str, Any]]:
-    policies: list[dict[str, Any]] = []
+def _collect_resource_policies(
+    iam_client: BaseClient, spec: _IamPolicyResource
+) -> tuple[list[dict[str, object]], list[dict[str, str]]]:
+    """Collect one IAM resource kind while retaining per-entity failures."""
 
-    sso_admin_client = session.client("sso-admin")
+    names: list[str] = []
+    paginator = iam_client.get_paginator(spec.list_operation)
+    for page in paginator.paginate():
+        for resource in page.get(spec.list_result_key, []):
+            name = resource.get(spec.name_key)
+            if isinstance(name, str):
+                names.append(name)
 
-    try:
-        instances = sso_admin_client.list_instances().get("Instances", [])
-    except ClientError as error:
-        __LOGGER__.warning(f"Unable to list SSO instances: {error}")
-        return policies
+    def collect_entity(
+        entity_name: str,
+    ) -> tuple[list[dict[str, object]], list[dict[str, str]]]:
+        policies: list[dict[str, object]] = []
+        errors: list[dict[str, str]] = []
+        request = {spec.name_key: entity_name}
+        try:
+            policy_paginator = iam_client.get_paginator(spec.list_policy_operation)
+            policy_names = [
+                policy_name
+                for page in policy_paginator.paginate(**request)
+                for policy_name in page.get("PolicyNames", [])
+                if isinstance(policy_name, str)
+            ]
+            operation = getattr(iam_client, spec.get_policy_operation)
+            for policy_name in policy_names:
+                try:
+                    response = operation(**request, PolicyName=policy_name)
+                    policies.append(
+                        {
+                            "EntityType": spec.result_key,
+                            "EntityName": entity_name,
+                            "PolicyType": "Inline",
+                            "PolicyName": policy_name,
+                            "PolicyDocument": response["PolicyDocument"],
+                        }
+                    )
+                except ClientError as error:
+                    errors.append(
+                        {
+                            "entity_type": spec.result_key,
+                            "entity_name": entity_name,
+                            "policy_name": policy_name,
+                            "error": str(error),
+                        }
+                    )
+        except ClientError as error:
+            errors.append(
+                {
+                    "entity_type": spec.result_key,
+                    "entity_name": entity_name,
+                    "error": str(error),
+                }
+            )
+        return policies, errors
 
-    for instance in instances:
-        instance_arn = instance["InstanceArn"]
-
-        permission_set_paginator = sso_admin_client.get_paginator(
-            "list_permission_sets"
+    policies: list[dict[str, object]] = []
+    errors: list[dict[str, str]] = []
+    with ThreadPoolExecutor(
+        max_workers=min(MAX_IAM_WORKERS, max(1, len(names)))
+    ) as executor:
+        for entity_policies, entity_errors in executor.map(collect_entity, names):
+            policies.extend(entity_policies)
+            errors.extend(entity_errors)
+    policies.sort(key=lambda item: (str(item["EntityName"]), str(item["PolicyName"])))
+    errors.sort(
+        key=lambda item: (
+            item.get("entity_type", ""),
+            item.get("entity_name", ""),
+            item.get("policy_name", ""),
         )
+    )
+    return policies, errors
 
-        for permission_set_page in permission_set_paginator.paginate(
-            InstanceArn=instance_arn
-        ):
-            for permission_set_arn in permission_set_page.get("PermissionSets", []):
-                try:
-                    permission_set_description = (
-                        sso_admin_client.describe_permission_set(
-                            InstanceArn=instance_arn,
-                            PermissionSetArn=permission_set_arn,
-                        )["PermissionSet"]
-                    )
 
-                    permission_set_name = permission_set_description.get(
-                        "Name", permission_set_arn
-                    )
+def _requested_types(metadata: dict[str, object]) -> list[str]:
+    """Validate and normalize requested IAM policy resource types."""
 
-                except ClientError:
-                    permission_set_name = permission_set_arn
-
-                try:
-                    inline_policy_json = (
-                        sso_admin_client.get_inline_policy_for_permission_set(
-                            InstanceArn=instance_arn,
-                            PermissionSetArn=permission_set_arn,
-                        ).get("InlinePolicy")
-                    )
-
-                    if inline_policy_json:
-                        policies.append(
-                            {
-                                "EntityType": "SSOPermissionSet",
-                                "EntityName": permission_set_name,
-                                "PolicyType": "Inline",
-                                "PermissionSetArn": permission_set_arn,
-                                "PolicyDocument": json.loads(inline_policy_json),
-                            }
-                        )
-
-                except ClientError:
-                    continue
-
-    return policies
+    raw_types = metadata.get("types", list(RESOURCE_SPECS))
+    if not isinstance(raw_types, list) or not raw_types:
+        raise RuntimeError(
+            "get_aws_inline_policies expects metadata.types to be a non-empty array"
+        )
+    requested: list[str] = []
+    for value in raw_types:
+        if not isinstance(value, str) or not value.strip():
+            raise RuntimeError(
+                "get_aws_inline_policies expects metadata.types to contain strings"
+            )
+        normalized = value.strip().lower()
+        if normalized not in RESOURCE_SPECS:
+            raise RuntimeError(
+                f"Unsupported IAM policy type {value!r}; expected one of "
+                f"{sorted(RESOURCE_SPECS)}. Use get_aws_sso_inline_policies for "
+                "Identity Center permission sets."
+            )
+        if normalized not in requested:
+            requested.append(normalized)
+    return requested
 
 
 def run(
@@ -202,110 +180,60 @@ def run(
     dependency_data: dict[str, object],
     actions: ActionRecorder,
 ) -> dict[str, object]:
-    """Gather AWS inline policies for IAM identities and Identity Center.
-
-    This is a read-only AWS task. By default it collects inline policies from
-    IAM users, roles, groups, and IAM Identity Center permission sets. Identity
-    Center permission set policies are collected only when the current account
-    is the AWS Organizations management account.
+    """Gather IAM inline policies once for each resolved AWS account.
 
     Metadata:
-        types: Optional list of policy categories to collect. Supported values
-            are `user`, `role`, `group`, and `sso`. Defaults to all categories.
+        types: Optional non-empty array containing `user`, `role`, or `group`.
+            Defaults to all three. Use `get_aws_sso_inline_policies` for IAM
+            Identity Center permission-set policies.
 
     Args:
         provider: Provider name for the current execution target.
         execution_target_id: Target AWS account ID.
         execution_target_name: Friendly name for the target account.
         execution_target_type: Provider target type.
-        region: Current AWS region.
-        session: Boto3 session scoped to the current region.
+        region: First resolved AWS region; IAM itself is account-wide.
+        session: Boto3 session scoped to the resolved AWS account.
         dry_run: Whether execution is running in dry-run mode.
         metadata: Task metadata containing optional policy type filters.
-        dependency_data: Runtime data selected from declared task dependencies.
+        dependency_data: Runtime dependency data; this task requires none.
         actions: Action recorder provided by the engine.
 
     Returns:
-        A payload with account context and collected policies grouped by
-        policy category.
+        Policies grouped by IAM resource type plus collection error details.
 
     Raises:
-        ValueError: If metadata.types is not a list of supported strings.
+        RuntimeError: If metadata.types is invalid.
+        TaskExecutionError: If collection is partial; partial_result retains
+            all successfully collected policies.
     """
-    account_id = execution_target_id
-    account_alias = execution_target_name
 
-    raw_types = metadata.get("types")
-
-    if raw_types is None:
-        requested_types: list[str] = ["user", "role", "group", "sso"]
-
-    elif isinstance(raw_types, list):
-        requested_types = []
-
-        for entry in raw_types:
-            if not isinstance(entry, str):
-                raise ValueError("metadata.types must contain only strings")
-            requested_types.append(entry)
-
-    else:
-        raise ValueError("metadata.types must be a list[str]")
-
-    normalized_types = {policy_type.lower() for policy_type in requested_types}
-
-    invalid_types = normalized_types - SUPPORTED_POLICY_TYPES
-    if invalid_types:
-        raise ValueError(f"Unsupported policy types requested: {sorted(invalid_types)}")
-
-    iam_client = session.client("iam")
-
-    result: dict[str, object] = {
-        "account_id": account_id,
-        "account_alias": account_alias,
-        "policies": {},
-    }
-
-    __LOGGER__.info(
-        f"Gathering inline policies in account '{account_alias}' ({account_id})"
-    )
-
-    if "user" in normalized_types:
-        actions.record("Gathering user inline policies")
-        result["policies"]["User"] = _list_user_policies(iam_client)
-
-    if "role" in normalized_types:
-        actions.record("Gathering role inline policies")
-        result["policies"]["Role"] = _list_role_policies(iam_client)
-
-    if "group" in normalized_types:
-        actions.record("Gathering group inline policies")
-        result["policies"]["Group"] = _list_group_policies(iam_client)
-
-    if "sso" in normalized_types:
+    iam_client: BaseClient = session.client("iam")
+    policies: dict[str, list[dict[str, object]]] = {}
+    errors: list[dict[str, str]] = []
+    for resource_type in _requested_types(metadata):
+        spec = RESOURCE_SPECS[resource_type]
         try:
-            org_client = session.client("organizations")
-            organization = org_client.describe_organization()["Organization"]
-
-            if account_id == organization["MasterAccountId"]:
-                actions.record("Gathering SSO permission set inline policies")
-                result["policies"]["SSOPermissionSet"] = _list_sso_policies(session)
-            else:
-                __LOGGER__.info(
-                    f"Skipping SSO inline policies in non-management account "
-                    f"'{account_id}'"
-                )
-
+            collected, collection_errors = _collect_resource_policies(iam_client, spec)
         except ClientError as error:
-            __LOGGER__.warning(
-                f"Unable to determine management account for SSO policy collection: {error}"
-            )
+            collected = []
+            collection_errors = [{"entity_type": spec.result_key, "error": str(error)}]
+        policies[spec.result_key] = collected
+        errors.extend(collection_errors)
 
-    policy_summary = {
-        policy_category: len(policy_list)
-        for policy_category, policy_list in result["policies"].items()
-        if isinstance(policy_list, list)
+    policy_count = sum(len(items) for items in policies.values())
+    result: dict[str, object] = {
+        "policies": policies,
+        "policy_count": policy_count,
+        "error_count": len(errors),
+        "errors": errors,
     }
-
-    actions.record(f"Policy summary: {policy_summary}")
-
+    actions.record(
+        f"Collected {policy_count} IAM inline polic(ies) with {len(errors)} error(s)"
+    )
+    if errors:
+        raise TaskExecutionError(
+            f"get_aws_inline_policies encountered {len(errors)} collection error(s)",
+            partial_result=result,
+        )
     return result

--- a/src/anvil/providers/aws/tasks/get_aws_sso_inline_policies.py
+++ b/src/anvil/providers/aws/tasks/get_aws_sso_inline_policies.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+from anvil.actions import ActionRecorder
+from anvil.task_errors import TaskExecutionError
+
+TASK_SCOPE = "configured_target"
+MAX_IDENTITY_CENTER_WORKERS = 5
+BOTO_CONFIG = Config(max_pool_connections=20)
+
+
+def _identity_center_region(metadata: dict[str, object], default: str) -> str:
+    """Return the configured IAM Identity Center endpoint region."""
+
+    value = metadata.get("identity_center_region", default)
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError(
+            "get_aws_sso_inline_policies expects metadata.identity_center_region "
+            "to be a non-empty string"
+        )
+    return value.strip()
+
+
+def _permission_set_arns(sso_admin_client, instance_arn: str) -> list[str]:
+    """Return every permission-set ARN for one Identity Center instance."""
+
+    paginator = sso_admin_client.get_paginator("list_permission_sets")
+    return [
+        arn
+        for page in paginator.paginate(InstanceArn=instance_arn)
+        for arn in page.get("PermissionSets", [])
+        if isinstance(arn, str)
+    ]
+
+
+def run(
+    *,
+    provider: str,
+    execution_target_id: str,
+    execution_target_name: str,
+    execution_target_type: str,
+    region: str,
+    session: boto3.Session,
+    dry_run: bool,
+    metadata: dict[str, object],
+    dependency_data: dict[str, object],
+    actions: ActionRecorder,
+) -> dict[str, object]:
+    """Gather Identity Center permission-set inline policies once per target.
+
+    Metadata:
+        identity_center_region: Optional non-empty AWS region containing IAM
+            Identity Center. Defaults to the configured target's first region.
+
+    Args:
+        provider: Provider name for the current execution target.
+        execution_target_id: Target AWS account ID.
+        execution_target_name: Friendly name for the target account.
+        execution_target_type: Provider target type.
+        region: First resolved AWS region.
+        session: Boto3 session scoped to the configured AWS target.
+        dry_run: Whether execution is running in dry-run mode.
+        metadata: Task metadata containing the optional endpoint region.
+        dependency_data: Runtime dependency data; this task requires none.
+        actions: Action recorder provided by the engine.
+
+    Returns:
+        Permission-set inline policies plus collection error details.
+
+    Raises:
+        RuntimeError: If the endpoint region is invalid.
+        TaskExecutionError: If collection is partial; partial_result retains
+            all successfully collected policies.
+    """
+
+    endpoint_region = _identity_center_region(metadata, region)
+    client = session.client(
+        "sso-admin", region_name=endpoint_region, config=BOTO_CONFIG
+    )
+    instances = client.list_instances().get("Instances", [])
+    work: list[tuple[str, str]] = []
+    errors: list[dict[str, str]] = []
+    for instance in instances:
+        instance_arn = instance.get("InstanceArn")
+        if isinstance(instance_arn, str):
+            try:
+                work.extend(
+                    (instance_arn, permission_set_arn)
+                    for permission_set_arn in _permission_set_arns(client, instance_arn)
+                )
+            except ClientError as error:
+                errors.append({"instance_arn": instance_arn, "error": str(error)})
+
+    def collect(
+        item: tuple[str, str],
+    ) -> tuple[dict[str, object] | None, dict[str, str] | None]:
+        instance_arn, permission_set_arn = item
+        try:
+            description = client.describe_permission_set(
+                InstanceArn=instance_arn, PermissionSetArn=permission_set_arn
+            )["PermissionSet"]
+            name = description.get("Name", permission_set_arn)
+            inline_policy = client.get_inline_policy_for_permission_set(
+                InstanceArn=instance_arn, PermissionSetArn=permission_set_arn
+            ).get("InlinePolicy")
+            if not inline_policy:
+                return None, None
+            if not isinstance(inline_policy, str):
+                raise RuntimeError("AWS returned a non-string inline policy document")
+            return (
+                {
+                    "EntityType": "SSOPermissionSet",
+                    "EntityName": name,
+                    "PolicyType": "Inline",
+                    "PermissionSetArn": permission_set_arn,
+                    "PolicyDocument": json.loads(inline_policy),
+                },
+                None,
+            )
+        except (ClientError, json.JSONDecodeError, RuntimeError) as error:
+            return None, {"permission_set_arn": permission_set_arn, "error": str(error)}
+
+    policies: list[dict[str, object]] = []
+    with ThreadPoolExecutor(
+        max_workers=min(MAX_IDENTITY_CENTER_WORKERS, max(1, len(work)))
+    ) as executor:
+        for policy, error in executor.map(collect, work):
+            if policy is not None:
+                policies.append(policy)
+            if error is not None:
+                errors.append(error)
+
+    policies.sort(key=lambda item: str(item.get("PermissionSetArn", "")))
+    errors.sort(
+        key=lambda item: (
+            item.get("instance_arn", ""),
+            item.get("permission_set_arn", ""),
+        )
+    )
+    result: dict[str, object] = {
+        "identity_center_region": endpoint_region,
+        "policies": policies,
+        "policy_count": len(policies),
+        "error_count": len(errors),
+        "errors": errors,
+    }
+    actions.record(
+        f"Collected {len(policies)} Identity Center inline polic(ies) with "
+        f"{len(errors)} error(s)"
+    )
+    if errors:
+        raise TaskExecutionError(
+            f"get_aws_sso_inline_policies encountered {len(errors)} "
+            "collection error(s)",
+            partial_result=result,
+        )
+    return result

--- a/src/anvil/providers/aws/tasks/get_organization_structure.py
+++ b/src/anvil/providers/aws/tasks/get_organization_structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import boto3
@@ -10,6 +11,8 @@ from botocore.exceptions import ClientError
 from anvil.actions import ActionRecorder
 
 __LOGGER__ = logging.getLogger(__name__)
+TASK_SCOPE = "configured_target"
+MAX_MANAGEMENT_WORKERS = 5
 
 
 def _list_organizational_units(
@@ -22,7 +25,11 @@ def _list_organizational_units(
     for page in paginator.paginate(ParentId=parent_id):
         for organizational_unit in page.get("OrganizationalUnits", []):
             organizational_units.append(
-                {"Name": organizational_unit["Name"], "Id": organizational_unit["Id"]}
+                {
+                    "Name": organizational_unit["Name"],
+                    "Id": organizational_unit["Id"],
+                    "ParentId": parent_id,
+                }
             )
 
     return organizational_units
@@ -41,22 +48,91 @@ def _list_policies_for_target(
     return policies
 
 
-def _list_accounts(org_client: BaseClient) -> list[dict[str, object]]:
+def _list_all_organizational_units(
+    root_id: str, org_client: BaseClient
+) -> list[dict[str, object]]:
+    """Return every OU below the root with parent relationships preserved."""
+
+    organizational_units: list[dict[str, object]] = []
+    pending_parent_ids = [root_id]
+    while pending_parent_ids:
+        parent_id = pending_parent_ids.pop()
+        children = _list_organizational_units(parent_id, org_client)
+        organizational_units.extend(children)
+        pending_parent_ids.extend(
+            child_id
+            for child in children
+            if isinstance((child_id := child.get("Id")), str)
+        )
+    return organizational_units
+
+
+def _list_accounts_for_parents(
+    org_client: BaseClient, parent_ids: list[str]
+) -> list[dict[str, object]]:
+    """Return accounts directly contained by the supplied roots and OUs."""
+
     accounts: list[dict[str, object]] = []
 
-    paginator = org_client.get_paginator("list_accounts")
+    def list_for_parent(parent_id: str) -> list[dict[str, object]]:
+        parent_accounts: list[dict[str, object]] = []
+        paginator = org_client.get_paginator("list_accounts_for_parent")
+        for page in paginator.paginate(ParentId=parent_id):
+            for account in page.get("Accounts", []):
+                account_copy = dict(account)
+                account_copy["ParentId"] = parent_id
+                joined_timestamp = account_copy.get("JoinedTimestamp")
+                if joined_timestamp is not None:
+                    account_copy["JoinedTimestamp"] = joined_timestamp.isoformat()
+                parent_accounts.append(account_copy)
+        return parent_accounts
 
-    for page in paginator.paginate():
-        for account in page.get("Accounts", []):
-            account_copy = dict(account)
-
-            joined_timestamp = account_copy.get("JoinedTimestamp")
-            if joined_timestamp is not None:
-                account_copy["JoinedTimestamp"] = joined_timestamp.isoformat()
-
-            accounts.append(account_copy)
+    with ThreadPoolExecutor(
+        max_workers=min(MAX_MANAGEMENT_WORKERS, max(1, len(parent_ids)))
+    ) as executor:
+        for parent_accounts in executor.map(list_for_parent, parent_ids):
+            accounts.extend(parent_accounts)
 
     return accounts
+
+
+def _enrich_organizational_unit(
+    organizational_unit: dict[str, object],
+    *,
+    org_client: BaseClient,
+    control_tower_client: BaseClient,
+) -> dict[str, object]:
+    """Add policies, ARN, and enabled controls to one OU record."""
+
+    enriched = dict(organizational_unit)
+    ou_id = enriched.get("Id")
+    if not isinstance(ou_id, str):
+        raise TypeError("OrganizationalUnit Id must be a string")
+    enriched["Policies"] = _list_policies_for_target(ou_id, org_client)
+    description = org_client.describe_organizational_unit(OrganizationalUnitId=ou_id)[
+        "OrganizationalUnit"
+    ]
+    ou_arn = description["Arn"]
+    if not isinstance(ou_arn, str):
+        raise TypeError("OrganizationalUnit Arn must be a string")
+    enriched["Arn"] = ou_arn
+    enriched["EnabledControls"] = _list_enabled_controls_for_ou(
+        control_tower_client, ou_arn
+    )
+    return enriched
+
+
+def _enrich_account(
+    account: dict[str, object], *, org_client: BaseClient
+) -> dict[str, object]:
+    """Add attached service-control policies to one account record."""
+
+    enriched = dict(account)
+    account_id = enriched.get("Id")
+    if not isinstance(account_id, str):
+        raise TypeError("Account Id must be a string")
+    enriched["Policies"] = _list_policies_for_target(account_id, org_client)
+    return enriched
 
 
 def _list_enabled_controls_for_ou(
@@ -150,43 +226,39 @@ def run(
 
     __LOGGER__.debug(f"Resolved root ID '{root_id}'")
 
-    organizational_units = _list_organizational_units(root_id, org_client)
-    accounts = _list_accounts(org_client)
+    discovered_ous = _list_all_organizational_units(root_id, org_client)
+    parent_ids = [root_id] + [
+        ou_id
+        for organizational_unit in discovered_ous
+        if isinstance((ou_id := organizational_unit.get("Id")), str)
+    ]
+    accounts = _list_accounts_for_parents(org_client, parent_ids)
 
-    for organizational_unit in organizational_units:
-        ou_id_value = organizational_unit.get("Id")
-        if not isinstance(ou_id_value, str):
-            raise TypeError("OrganizationalUnit Id must be a string")
-
-        __LOGGER__.debug(f"Gathering SCPs for OU '{organizational_unit.get('Name')}'")
-
-        organizational_unit["Policies"] = _list_policies_for_target(
-            ou_id_value, org_client
+    with ThreadPoolExecutor(
+        max_workers=min(MAX_MANAGEMENT_WORKERS, max(1, len(discovered_ous)))
+    ) as executor:
+        organizational_units = list(
+            executor.map(
+                lambda item: _enrich_organizational_unit(
+                    item,
+                    org_client=org_client,
+                    control_tower_client=control_tower_client,
+                ),
+                discovered_ous,
+            )
         )
 
-        describe_response = org_client.describe_organizational_unit(
-            OrganizationalUnitId=ou_id_value
+    with ThreadPoolExecutor(
+        max_workers=min(MAX_MANAGEMENT_WORKERS, max(1, len(accounts)))
+    ) as executor:
+        accounts = list(
+            executor.map(
+                lambda item: _enrich_account(item, org_client=org_client), accounts
+            )
         )
 
-        ou_arn = describe_response["OrganizationalUnit"]["Arn"]
-
-        __LOGGER__.debug(
-            f"Gathering Control Tower enabled controls for OU "
-            f"'{organizational_unit.get('Name')}'"
-        )
-
-        organizational_unit["EnabledControls"] = _list_enabled_controls_for_ou(
-            control_tower_client, ou_arn
-        )
-
-    for account in accounts:
-        account_id_value = account.get("Id")
-        if not isinstance(account_id_value, str):
-            raise TypeError("Account Id must be a string")
-
-        __LOGGER__.debug(f"Gathering SCPs for account '{account.get('Name')}'")
-
-        account["Policies"] = _list_policies_for_target(account_id_value, org_client)
+    organizational_units.sort(key=lambda item: str(item.get("Id", "")))
+    accounts.sort(key=lambda item: str(item.get("Id", "")))
 
     actions.record(
         f"Collected {len(organizational_units)} OUs and {len(accounts)} accounts"

--- a/src/anvil/providers/aws/tasks/remove_iam_user.py
+++ b/src/anvil/providers/aws/tasks/remove_iam_user.py
@@ -6,8 +6,11 @@ from typing import Any
 from botocore.exceptions import ClientError
 
 from anvil.actions import ActionRecorder
+from anvil.providers.tasks._task_helpers import metadata_string_array
+from anvil.task_errors import TaskExecutionError
 
 __LOGGER__ = logging.getLogger(__name__)
+TASK_SCOPE = "target"
 
 
 def _list_paginated_user_resources(
@@ -29,7 +32,14 @@ def _list_paginated_user_resources(
 
 def cleanup_user_resources(
     iam_client, user_name: str, dry_run: bool, actions: ActionRecorder
-) -> None:
+) -> int:
+    """Remove or plan removal of resources attached to one IAM user.
+
+    Returns:
+        The number of attached resources discovered for removal.
+    """
+
+    resource_count = 0
     # Groups
     groups = _list_paginated_user_resources(
         iam_client,
@@ -38,6 +48,7 @@ def cleanup_user_resources(
         user_name=user_name,
     )
     for group in groups:
+        resource_count += 1
         name = group["GroupName"]
         if dry_run:
             __LOGGER__.debug(f"(dry-run) Would remove user from group: {name}")
@@ -53,6 +64,7 @@ def cleanup_user_resources(
         user_name=user_name,
     )
     for key in access_keys:
+        resource_count += 1
         key_id = key["AccessKeyId"]
         if dry_run:
             __LOGGER__.debug(f"(dry-run) Would delete access key: {key_id}")
@@ -68,6 +80,7 @@ def cleanup_user_resources(
         user_name=user_name,
     )
     for device in mfa_devices:
+        resource_count += 1
         serial = device["SerialNumber"]
         if dry_run:
             __LOGGER__.debug(f"(dry-run) Would deactivate MFA device: {serial}")
@@ -85,6 +98,7 @@ def cleanup_user_resources(
         user_name=user_name,
     )
     for ssh in ssh_keys:
+        resource_count += 1
         ssh_id = ssh["SSHPublicKeyId"]
         if dry_run:
             __LOGGER__.debug(f"(dry-run) Would delete SSH key: {ssh_id}")
@@ -102,6 +116,7 @@ def cleanup_user_resources(
             raise
 
     for cred in svc_creds.get("ServiceSpecificCredentials", []):
+        resource_count += 1
         cred_id = cred["ServiceSpecificCredentialId"]
         if dry_run:
             __LOGGER__.debug(f"(dry-run) Would delete service credential: {cred_id}")
@@ -119,6 +134,7 @@ def cleanup_user_resources(
         user_name=user_name,
     )
     for cert in certificates:
+        resource_count += 1
         cert_id = cert["CertificateId"]
         if dry_run:
             __LOGGER__.debug(f"(dry-run) Would delete certificate: {cert_id}")
@@ -136,6 +152,7 @@ def cleanup_user_resources(
         user_name=user_name,
     )
     for policy in attached_policies:
+        resource_count += 1
         arn = policy["PolicyArn"]
         if dry_run:
             __LOGGER__.debug(f"(dry-run) Would detach policy: {arn}")
@@ -151,6 +168,7 @@ def cleanup_user_resources(
         user_name=user_name,
     )
     for name in inline_policy_names:
+        resource_count += 1
         if dry_run:
             __LOGGER__.debug(f"(dry-run) Would delete inline policy: {name}")
         else:
@@ -166,6 +184,7 @@ def cleanup_user_resources(
     )
     tag_keys = [tag["Key"] for tag in tags]
     if tag_keys:
+        resource_count += len(tag_keys)
         if dry_run:
             __LOGGER__.debug(f"(dry-run) Would remove tags: {tag_keys}")
         else:
@@ -175,6 +194,7 @@ def cleanup_user_resources(
     # Login Profile
     try:
         iam_client.get_login_profile(UserName=user_name)
+        resource_count += 1
         if dry_run:
             __LOGGER__.debug("(dry-run) Would delete login profile")
         else:
@@ -184,6 +204,33 @@ def cleanup_user_resources(
         if error.response["Error"]["Code"] != "NoSuchEntity":
             __LOGGER__.error(f"Error deleting login profile for {user_name}: {error}")
             raise
+
+    return resource_count
+
+
+def _selected_users(metadata: dict[str, object]) -> list[str]:
+    """Return the required, normalized IAM user selectors."""
+
+    users = metadata_string_array(
+        task_name="remove_iam_user", metadata=metadata, key="users", required=True
+    )
+    if users is None:  # The shared validator guarantees this for required arrays.
+        raise RuntimeError(
+            "remove_iam_user requires metadata.users to be a non-empty array"
+        )
+    return users
+
+
+def _user_exists(iam_client, user_name: str) -> bool:
+    """Return whether an IAM user currently exists."""
+
+    try:
+        iam_client.get_user(UserName=user_name)
+    except ClientError as error:
+        if error.response["Error"]["Code"] == "NoSuchEntity":
+            return False
+        raise
+    return True
 
 
 def run(
@@ -198,18 +245,17 @@ def run(
     metadata: dict[str, object],
     dependency_data: dict[str, object],
     actions: ActionRecorder,
-) -> None:
-    """Remove IAM resources attached to a configured IAM user.
+) -> dict[str, object]:
+    """Remove selected IAM users after cleaning their attached resources.
 
-    This AWS task deletes user-attached resources before user deletion workflows.
-    It removes group memberships, access keys, MFA devices, SSH public keys,
+    This target-scoped AWS task runs once per resolved account and removes
+    group memberships, access keys, MFA devices, SSH public keys,
     service-specific credentials, signing certificates, attached policies,
-    inline policies, tags, and the console login profile. In dry-run mode it
-    logs planned deletions without mutating IAM resources.
+    inline policies, tags, and the console login profile, then deletes each IAM
+    user. In dry-run mode it reports planned deletions without mutating IAM.
 
     Metadata:
-        user_name: Required IAM user name whose attached resources should be
-            removed.
+        users: Required non-empty array of IAM user names to remove.
 
     Args:
         provider: Provider name for the current execution target.
@@ -219,32 +265,74 @@ def run(
         region: Current AWS region.
         session: Boto3 session scoped to the current region.
         dry_run: Whether execution is running in dry-run mode.
-        metadata: Task metadata containing the IAM user name.
+        metadata: Task metadata containing IAM user selectors.
         dependency_data: Runtime data selected from declared task dependencies.
         actions: Action recorder provided by the engine.
 
+    Returns:
+        A payload containing planned, removed, skipped, and failed IAM users
+        plus discovered attached-resource counts.
+
     Raises:
-        RuntimeError: If metadata.user_name is missing or not a string.
+        RuntimeError: If ``metadata.users`` is missing or invalid.
         botocore.exceptions.ClientError: If an unexpected AWS API error occurs.
+        TaskExecutionError: If one or more selected users fail to be removed.
     """
-    user_name = metadata.get("user_name")
-
-    if not isinstance(user_name, str):
-        raise RuntimeError("remove_iam_user requires metadata.user_name to be a string")
-
-    if not dry_run:
-        __LOGGER__.info(
-            f"Cleaning IAM user '{user_name}' in account "
-            f"{execution_target_name} ({execution_target_id})"
-        )
-
+    user_names = _selected_users(metadata)
     iam_client = session.client("iam")
+    planned: list[dict[str, object]] = []
+    removed: list[dict[str, object]] = []
+    skipped: list[dict[str, object]] = []
+    failed: list[dict[str, object]] = []
 
-    cleanup_user_resources(
-        iam_client=iam_client, user_name=user_name, dry_run=dry_run, actions=actions
-    )
+    for user_name in user_names:
+        try:
+            if not _user_exists(iam_client, user_name):
+                skipped.append({"user_name": user_name, "reason": "not_found"})
+                __LOGGER__.info(f"IAM user '{user_name}' does not exist; skipping")
+                continue
 
+            resource_count = cleanup_user_resources(
+                iam_client=iam_client,
+                user_name=user_name,
+                dry_run=dry_run,
+                actions=actions,
+            )
+            user_result: dict[str, object] = {
+                "user_name": user_name,
+                "attached_resource_count": resource_count,
+            }
+            if dry_run:
+                planned.append(user_result)
+                __LOGGER__.info(f"(dry-run) Would remove IAM user '{user_name}'")
+            else:
+                iam_client.delete_user(UserName=user_name)
+                removed.append(user_result)
+                __LOGGER__.info(f"Removed IAM user '{user_name}'")
+        except ClientError as error:
+            failed.append({"user_name": user_name, "error": str(error)})
+            __LOGGER__.warning(f"Failed to remove IAM user '{user_name}': {error}")
+
+    result: dict[str, object] = {
+        "selected_count": len(user_names),
+        "planned_count": len(planned),
+        "removed_count": len(removed),
+        "skipped_count": len(skipped),
+        "failed_count": len(failed),
+        "planned_users": planned,
+        "removed_users": removed,
+        "skipped_users": skipped,
+        "failed_users": failed,
+    }
     if dry_run:
-        actions.record(f"(dry-run) Would remove IAM user resources for {user_name}")
+        actions.record(f"(dry-run) Would remove {len(planned)} IAM user(s)")
     else:
-        actions.record(f"Removed IAM user resources for {user_name}")
+        actions.record(f"Removed {len(removed)} IAM user(s)")
+
+    if failed:
+        raise TaskExecutionError(
+            f"remove_iam_user failed to remove {len(failed)} of "
+            f"{len(user_names)} selected user(s)",
+            partial_result=result,
+        )
+    return result

--- a/src/anvil/providers/aws/tasks/remove_iam_user.py
+++ b/src/anvil/providers/aws/tasks/remove_iam_user.py
@@ -211,14 +211,9 @@ def cleanup_user_resources(
 def _selected_users(metadata: dict[str, object]) -> list[str]:
     """Return the required, normalized IAM user selectors."""
 
-    users = metadata_string_array(
+    return metadata_string_array(
         task_name="remove_iam_user", metadata=metadata, key="users", required=True
     )
-    if users is None:  # The shared validator guarantees this for required arrays.
-        raise RuntimeError(
-            "remove_iam_user requires metadata.users to be a non-empty array"
-        )
-    return users
 
 
 def _user_exists(iam_client, user_name: str) -> bool:

--- a/src/anvil/providers/aws/tasks/remove_idc_user.py
+++ b/src/anvil/providers/aws/tasks/remove_idc_user.py
@@ -12,6 +12,7 @@ from anvil.providers.tasks._task_helpers import metadata_string_array
 from anvil.task_errors import TaskExecutionError
 
 __LOGGER__ = logging.getLogger(__name__)
+TASK_SCOPE = "configured_target"
 
 BOTO_CONFIG = Config(max_pool_connections=40)
 

--- a/src/anvil/providers/aws/tasks/remove_missing_group_assignments.py
+++ b/src/anvil/providers/aws/tasks/remove_missing_group_assignments.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
 import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import boto3
 from botocore.config import Config
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 
 from anvil.actions import ActionRecorder
+from anvil.task_errors import TaskExecutionError
 
 __LOGGER__ = logging.getLogger(__name__)
+TASK_SCOPE = "configured_target"
 
 BOTO_CONFIG = Config(max_pool_connections=40)
+MAX_MANAGEMENT_WORKERS = 5
+DELETION_POLL_INTERVAL_SECONDS = 1.0
+DELETION_MAX_ATTEMPTS = 60
 
 
 def _get_active_sso_instance(sso_admin_client) -> tuple[str, str, str]:
@@ -53,22 +60,33 @@ def _get_permission_set_name_cache(
 
     paginator = sso_admin_client.get_paginator("list_permission_sets")
 
-    for page in paginator.paginate(InstanceArn=instance_arn):
-        for permission_set_arn in page.get("PermissionSets", []):
-            try:
-                description = sso_admin_client.describe_permission_set(
-                    InstanceArn=instance_arn, PermissionSetArn=permission_set_arn
-                )["PermissionSet"]
+    permission_set_arns = [
+        permission_set_arn
+        for page in paginator.paginate(InstanceArn=instance_arn)
+        for permission_set_arn in page.get("PermissionSets", [])
+        if isinstance(permission_set_arn, str)
+    ]
 
-                permission_set_cache[permission_set_arn] = description.get(
-                    "Name", permission_set_arn
-                )
+    def describe(permission_set_arn: str) -> tuple[str, str]:
+        try:
+            description = sso_admin_client.describe_permission_set(
+                InstanceArn=instance_arn, PermissionSetArn=permission_set_arn
+            )["PermissionSet"]
+            name = description.get("Name", permission_set_arn)
+            return permission_set_arn, name if isinstance(
+                name, str
+            ) else permission_set_arn
+        except ClientError as error:
+            __LOGGER__.warning(
+                f"Could not describe permission set '{permission_set_arn}': {error}"
+            )
+            return permission_set_arn, permission_set_arn
 
-            except ClientError as error:
-                __LOGGER__.warning(
-                    f"Could not describe permission set '{permission_set_arn}': {error}"
-                )
-                permission_set_cache[permission_set_arn] = permission_set_arn
+    with ThreadPoolExecutor(
+        max_workers=min(MAX_MANAGEMENT_WORKERS, max(1, len(permission_set_arns)))
+    ) as executor:
+        for permission_set_arn, name in executor.map(describe, permission_set_arns):
+            permission_set_cache[permission_set_arn] = name
 
     return permission_set_cache
 
@@ -81,7 +99,9 @@ def _collect_group_assignments(
 ) -> list[dict[str, str]]:
     assignments: list[dict[str, str]] = []
 
-    for permission_set_arn, permission_set_name in permission_set_cache.items():
+    def collect_permission_set(item: tuple[str, str]) -> list[dict[str, str]]:
+        permission_set_arn, permission_set_name = item
+        collected: list[dict[str, str]] = []
         paginator = sso_admin_client.get_paginator(
             "list_accounts_for_provisioned_permission_set"
         )
@@ -103,7 +123,7 @@ def _collect_group_assignments(
                 ):
                     for assignment in assignment_page.get("AccountAssignments", []):
                         if assignment.get("PrincipalType") == "GROUP":
-                            assignments.append(
+                            collected.append(
                                 {
                                     "PermissionSetArn": permission_set_arn,
                                     "PermissionSetName": permission_set_name,
@@ -112,6 +132,14 @@ def _collect_group_assignments(
                                     "GroupId": assignment["PrincipalId"],
                                 }
                             )
+        return collected
+
+    permission_sets = list(permission_set_cache.items())
+    with ThreadPoolExecutor(
+        max_workers=min(MAX_MANAGEMENT_WORKERS, max(1, len(permission_sets)))
+    ) as executor:
+        for collected in executor.map(collect_permission_set, permission_sets):
+            assignments.extend(collected)
 
     return assignments
 
@@ -121,17 +149,71 @@ def _validate_groups(
 ) -> dict[str, bool]:
     group_existence: dict[str, bool] = {}
 
-    for group_id in group_ids:
+    def group_exists(group_id: str) -> tuple[str, bool]:
         try:
             identitystore_client.describe_group(
                 IdentityStoreId=identity_store_id, GroupId=group_id
             )
-            group_existence[group_id] = True
-
+            return group_id, True
         except identitystore_client.exceptions.ResourceNotFoundException:
-            group_existence[group_id] = False
+            return group_id, False
+
+    with ThreadPoolExecutor(
+        max_workers=min(MAX_MANAGEMENT_WORKERS, max(1, len(group_ids)))
+    ) as executor:
+        for group_id, exists in executor.map(group_exists, sorted(group_ids)):
+            group_existence[group_id] = exists
 
     return group_existence
+
+
+def _delete_assignment_and_wait(
+    sso_admin_client, *, instance_arn: str, entry: dict[str, str]
+) -> dict[str, str]:
+    """Delete one account assignment and wait for its terminal AWS status."""
+
+    response = sso_admin_client.delete_account_assignment(
+        InstanceArn=instance_arn,
+        TargetId=entry["AccountId"],
+        TargetType="AWS_ACCOUNT",
+        PermissionSetArn=entry["PermissionSetArn"],
+        PrincipalType="GROUP",
+        PrincipalId=entry["GroupId"],
+    )
+    raw_status = response.get("AccountAssignmentDeletionStatus", {})
+    if not isinstance(raw_status, dict):
+        raise RuntimeError("AWS returned an invalid account-assignment deletion status")
+    status = raw_status.get("Status")
+    request_id = raw_status.get("RequestId")
+
+    for _attempt in range(DELETION_MAX_ATTEMPTS):
+        if status == "SUCCEEDED":
+            return entry
+        if status == "FAILED":
+            reason = raw_status.get("FailureReason", "unknown failure")
+            raise RuntimeError(f"AWS account-assignment deletion failed: {reason}")
+        if status != "IN_PROGRESS" or not isinstance(request_id, str):
+            raise RuntimeError(
+                "AWS account-assignment deletion returned neither a terminal status "
+                "nor a request ID"
+            )
+        time.sleep(DELETION_POLL_INTERVAL_SECONDS)
+        response = sso_admin_client.describe_account_assignment_deletion_status(
+            InstanceArn=instance_arn, AccountAssignmentDeletionRequestId=request_id
+        )
+        next_status = response.get("AccountAssignmentDeletionStatus", {})
+        if not isinstance(next_status, dict):
+            raise RuntimeError(
+                "AWS returned an invalid account-assignment deletion status"
+            )
+        raw_status = next_status
+        status = raw_status.get("Status")
+        request_id = raw_status.get("RequestId", request_id)
+
+    raise RuntimeError(
+        f"AWS account-assignment deletion did not finish after "
+        f"{DELETION_MAX_ATTEMPTS} status checks"
+    )
 
 
 def run(
@@ -205,22 +287,15 @@ def run(
 
     org_client = session.client("organizations", config=BOTO_CONFIG)
 
-    instances_response = sso_admin_client.list_instances()
-    instances = instances_response.get("Instances", [])
-
-    active_instance = next(
-        (instance for instance in instances if instance.get("Status") == "ACTIVE"), None
-    )
-
-    if not active_instance:
+    try:
+        instance_arn, identity_store_id, owner_account_id = _get_active_sso_instance(
+            sso_admin_client
+        )
+    except ValueError as error:
         raise RuntimeError(
             f"No active Identity Center instance found in region "
             f"'{identity_center_region}'"
-        )
-
-    instance_arn = active_instance["InstanceArn"]
-    identity_store_id = active_instance["IdentityStoreId"]
-    owner_account_id = active_instance["OwnerAccountId"]
+        ) from error
 
     if account_id != owner_account_id:
         __LOGGER__.info(
@@ -264,32 +339,43 @@ def run(
         )
 
     removed: list[dict[str, str]] = []
+    failed: list[dict[str, str]] = []
 
-    for entry in missing_assignments:
-        if dry_run:
+    if dry_run:
+        for entry in missing_assignments:
             __LOGGER__.info(
                 f"(dry-run) Would remove GROUP '{entry['GroupId']}' "
                 f"from permission set '{entry['PermissionSetName']}' "
                 f"in account '{entry['AccountName']}'"
             )
-            continue
-
-        sso_admin_client.delete_account_assignment(
-            InstanceArn=instance_arn,
-            TargetId=entry["AccountId"],
-            TargetType="AWS_ACCOUNT",
-            PermissionSetArn=entry["PermissionSetArn"],
-            PrincipalType="GROUP",
-            PrincipalId=entry["GroupId"],
-        )
-
-        removed.append(entry)
-
-        __LOGGER__.info(
-            f"Removed GROUP '{entry['GroupId']}' "
-            f"from permission set '{entry['PermissionSetName']}' "
-            f"in account '{entry['AccountName']}'"
-        )
+    else:
+        with ThreadPoolExecutor(
+            max_workers=min(MAX_MANAGEMENT_WORKERS, max(1, len(missing_assignments)))
+        ) as executor:
+            future_to_entry = {
+                executor.submit(
+                    _delete_assignment_and_wait,
+                    sso_admin_client,
+                    instance_arn=instance_arn,
+                    entry=entry,
+                ): entry
+                for entry in missing_assignments
+            }
+            for future in as_completed(future_to_entry):
+                entry = future_to_entry[future]
+                try:
+                    removed.append(future.result())
+                    __LOGGER__.info(
+                        f"Removed GROUP '{entry['GroupId']}' from permission set "
+                        f"'{entry['PermissionSetName']}' in account "
+                        f"'{entry['AccountName']}'"
+                    )
+                except (BotoCoreError, RuntimeError) as error:
+                    failed.append({**entry, "Error": str(error)})
+                    __LOGGER__.warning(
+                        f"Failed to remove GROUP '{entry['GroupId']}' from "
+                        f"permission set '{entry['PermissionSetName']}': {error}"
+                    )
 
     if dry_run:
         actions.record(
@@ -299,9 +385,19 @@ def run(
     else:
         actions.record(f"Removed {len(removed)} missing group assignment(s)")
 
-    return {
+    result: dict[str, object] = {
         "identity_center_region": identity_center_region,
         "missing_count": len(missing_assignments),
+        "planned_count": len(missing_assignments) if dry_run else 0,
         "removed_count": len(removed),
+        "failed_count": len(failed),
         "missing": missing_assignments,
+        "failed": failed,
     }
+    if failed:
+        raise TaskExecutionError(
+            f"remove_missing_group_assignments failed to remove {len(failed)} of "
+            f"{len(missing_assignments)} assignment(s)",
+            partial_result=result,
+        )
+    return result

--- a/src/anvil/providers/azure/provider.py
+++ b/src/anvil/providers/azure/provider.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import logging
-import threading
-from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
@@ -28,6 +26,7 @@ from anvil.providers.base import (
 )
 from anvil.regions import is_region_selector, resolve_location_selectors
 from anvil.results import ExecutionStatus
+from anvil.singleflight import SingleFlightCache
 
 __LOGGER__ = logging.getLogger(__name__)
 
@@ -52,66 +51,9 @@ class AzureSubscription:
     display_name: str | None = None
 
 
-@dataclass(slots=True)
-class _AzureSubscriptionDiscoveryFlight:
-    event: threading.Event
-    subscriptions: list[AzureSubscription] | None = None
-    error: BaseException | None = None
-
-
-class _AzureSubscriptionDiscoveryCache:
-    """Single-flight cache for Azure subscription discovery only."""
-
-    def __init__(self) -> None:
-        self._values: dict[object, list[AzureSubscription]] = {}
-        self._flights: dict[object, _AzureSubscriptionDiscoveryFlight] = {}
-        self._lock = threading.Lock()
-
-    def get_or_discover(
-        self, *, key: object, discover: Callable[[], list[AzureSubscription]]
-    ) -> list[AzureSubscription]:
-        with self._lock:
-            cached = self._values.get(key)
-            if cached is not None:
-                return list(cached)
-
-            flight = self._flights.get(key)
-            if flight is None:
-                flight = _AzureSubscriptionDiscoveryFlight(event=threading.Event())
-                self._flights[key] = flight
-                owns_discovery = True
-            else:
-                owns_discovery = False
-
-        if owns_discovery:
-            try:
-                subscriptions = list(discover())
-            except BaseException as error:
-                with self._lock:
-                    flight.error = error
-                    self._flights.pop(key, None)
-                    flight.event.set()
-                raise
-
-            with self._lock:
-                cached = self._values.get(key)
-                stored = list(cached) if cached is not None else subscriptions
-                self._values[key] = list(stored)
-                flight.subscriptions = list(stored)
-                self._flights.pop(key, None)
-                flight.event.set()
-
-            return list(stored)
-
-        flight.event.wait()
-        if flight.error is not None:
-            raise flight.error
-        if flight.subscriptions is None:
-            raise RuntimeError("Azure subscription discovery completed empty")
-        return list(flight.subscriptions)
-
-
-_AZURE_SUBSCRIPTION_DISCOVERY_CACHE = _AzureSubscriptionDiscoveryCache()
+_AZURE_SUBSCRIPTION_DISCOVERY_CACHE = SingleFlightCache[
+    object, tuple[AzureSubscription, ...]
+]()
 
 
 @dataclass(frozen=True, slots=True)
@@ -732,12 +674,19 @@ class AzureProvider:
         discovery_key = self._subscription_discovery_cache_key(
             tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
         )
-        return _AZURE_SUBSCRIPTION_DISCOVERY_CACHE.get_or_discover(
-            key=discovery_key,
-            discover=lambda: self._session_factory.list_subscriptions(
-                tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
-            ),
+        subscriptions, _cache_hit, _cache_waited = (
+            _AZURE_SUBSCRIPTION_DISCOVERY_CACHE.get_or_create(
+                key=discovery_key,
+                create=lambda: tuple(
+                    self._session_factory.list_subscriptions(
+                        tenant_id=tenant_id,
+                        client_id=client_id,
+                        client_secret=client_secret,
+                    )
+                ),
+            )
         )
+        return list(subscriptions)
 
     def _subscription_discovery_cache_key(
         self, *, tenant_id: str | None, client_id: str | None, client_secret: str | None

--- a/src/anvil/providers/azure/provider.py
+++ b/src/anvil/providers/azure/provider.py
@@ -4,6 +4,10 @@ import logging
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from azure.core.credentials import TokenCredential
 
 from anvil.benchmark import BenchmarkRecorder
 from anvil.descriptors import TargetDescriptor
@@ -136,7 +140,7 @@ class AzureSession:
 
     subscription_id: str
     location: str
-    credential: object
+    credential: TokenCredential
 
 
 class AzureSessionFactory:
@@ -148,7 +152,7 @@ class AzureSessionFactory:
         tenant_id: str | None = None,
         client_id: str | None = None,
         client_secret: str | None = None,
-    ) -> object:
+    ) -> TokenCredential:
         try:
             from azure.identity import ClientSecretCredential, DefaultAzureCredential
         except ImportError as error:

--- a/src/anvil/providers/cloudflare/tasks/list_account_member.py
+++ b/src/anvil/providers/cloudflare/tasks/list_account_member.py
@@ -49,7 +49,9 @@ def run(
     selectors = metadata_string_array(
         task_name="list_account_member", metadata=metadata, key="members"
     )
-    maximum = metadata_int(metadata=metadata, key="max_results")
+    maximum = metadata_int(
+        task_name="list_account_member", metadata=metadata, key="max_results"
+    )
     accounts = getattr(session.client, "accounts", None)
     members_resource = getattr(accounts, "members", None)
     operation = getattr(members_resource, "list", None)

--- a/src/anvil/providers/cloudflare/tasks/list_dns_record.py
+++ b/src/anvil/providers/cloudflare/tasks/list_dns_record.py
@@ -45,7 +45,9 @@ def run(
         execution_target_type=execution_target_type,
         expected="zone",
     )
-    max_results = metadata_int(metadata=metadata, key="max_results")
+    max_results = metadata_int(
+        task_name="list_dns_record", metadata=metadata, key="max_results"
+    )
     dns = getattr(session.client, "dns", None)
     records = getattr(dns, "records", None)
     operation = getattr(records, "list", None)

--- a/src/anvil/providers/cloudflare/tasks/list_zone.py
+++ b/src/anvil/providers/cloudflare/tasks/list_zone.py
@@ -44,7 +44,9 @@ def run(
         execution_target_type=execution_target_type,
         expected="account",
     )
-    max_results = metadata_int(metadata=metadata, key="max_results")
+    max_results = metadata_int(
+        task_name="list_zone", metadata=metadata, key="max_results"
+    )
     resource = getattr(session.client, "zones", None)
     operation = getattr(resource, "list", None)
     if not callable(operation):

--- a/src/anvil/providers/datadog/tasks/list_dashboard.py
+++ b/src/anvil/providers/datadog/tasks/list_dashboard.py
@@ -38,7 +38,9 @@ def run(
     require_provider(task_name="list_dashboard", provider=provider, expected="datadog")
     from datadog_api_client.v1.api.dashboards_api import DashboardsApi
 
-    max_results = metadata_int(metadata=metadata, key="max_results")
+    max_results = metadata_int(
+        task_name="list_dashboard", metadata=metadata, key="max_results"
+    )
     response = DashboardsApi(session.client).list_dashboards(count=max_results)
     raw = getattr(response, "dashboards", None)
     if raw is None:

--- a/src/anvil/providers/datadog/tasks/list_monitor.py
+++ b/src/anvil/providers/datadog/tasks/list_monitor.py
@@ -32,7 +32,9 @@ def run(
     require_provider(task_name="list_monitor", provider=provider, expected="datadog")
     from datadog_api_client.v1.api.monitors_api import MonitorsApi
 
-    max_results = metadata_int(metadata=metadata, key="max_results")
+    max_results = metadata_int(
+        task_name="list_monitor", metadata=metadata, key="max_results"
+    )
     monitors = bounded(
         MonitorsApi(session.client).list_monitors(page_size=max_results),
         max_results=max_results,

--- a/src/anvil/providers/datadog/tasks/list_user.py
+++ b/src/anvil/providers/datadog/tasks/list_user.py
@@ -42,7 +42,7 @@ def run(
     require_provider(task_name="list_user", provider=provider, expected="datadog")
     from datadog_api_client.v2.api.users_api import UsersApi
 
-    maximum = metadata_int(metadata=metadata, key="max_results")
+    maximum = metadata_int(task_name="list_user", metadata=metadata, key="max_results")
     selectors = metadata_string_array(
         task_name="list_user", metadata=metadata, key="users"
     )

--- a/src/anvil/providers/gcp/provider.py
+++ b/src/anvil/providers/gcp/provider.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import threading
-from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
@@ -26,6 +24,7 @@ from anvil.providers.base import (
 )
 from anvil.regions import is_region_selector, resolve_location_selectors
 from anvil.results import ExecutionStatus
+from anvil.singleflight import SingleFlightCache
 
 DEFAULT_REGIONS = ("us-central1",)
 MODE_ORGANIZATION = "organization"
@@ -46,66 +45,7 @@ class GcpProject:
     display_name: str | None = None
 
 
-@dataclass(slots=True)
-class _GcpProjectDiscoveryFlight:
-    event: threading.Event
-    projects: list[GcpProject] | None = None
-    error: BaseException | None = None
-
-
-class _GcpProjectDiscoveryCache:
-    """Single-flight cache for GCP project discovery only."""
-
-    def __init__(self) -> None:
-        self._values: dict[object, list[GcpProject]] = {}
-        self._flights: dict[object, _GcpProjectDiscoveryFlight] = {}
-        self._lock = threading.Lock()
-
-    def get_or_discover(
-        self, *, key: object, discover: Callable[[], list[GcpProject]]
-    ) -> list[GcpProject]:
-        with self._lock:
-            cached = self._values.get(key)
-            if cached is not None:
-                return list(cached)
-
-            flight = self._flights.get(key)
-            if flight is None:
-                flight = _GcpProjectDiscoveryFlight(event=threading.Event())
-                self._flights[key] = flight
-                owns_discovery = True
-            else:
-                owns_discovery = False
-
-        if owns_discovery:
-            try:
-                projects = list(discover())
-            except BaseException as error:
-                with self._lock:
-                    flight.error = error
-                    self._flights.pop(key, None)
-                    flight.event.set()
-                raise
-
-            with self._lock:
-                cached = self._values.get(key)
-                stored = list(cached) if cached is not None else projects
-                self._values[key] = list(stored)
-                flight.projects = list(stored)
-                self._flights.pop(key, None)
-                flight.event.set()
-
-            return list(stored)
-
-        flight.event.wait()
-        if flight.error is not None:
-            raise flight.error
-        if flight.projects is None:
-            raise RuntimeError("GCP project discovery completed empty")
-        return list(flight.projects)
-
-
-_GCP_PROJECT_DISCOVERY_CACHE = _GcpProjectDiscoveryCache()
+_GCP_PROJECT_DISCOVERY_CACHE = SingleFlightCache[object, tuple[GcpProject, ...]]()
 
 
 @dataclass(frozen=True, slots=True)
@@ -525,12 +465,18 @@ class GcpProvider:
         discovery_key = self._project_discovery_cache_key(
             credentials_path=credentials_path, quota_project_id=quota_project_id
         )
-        return _GCP_PROJECT_DISCOVERY_CACHE.get_or_discover(
-            key=discovery_key,
-            discover=lambda: self._session_factory.list_projects(
-                credentials_path=credentials_path, quota_project_id=quota_project_id
-            ),
+        projects, _cache_hit, _cache_waited = (
+            _GCP_PROJECT_DISCOVERY_CACHE.get_or_create(
+                key=discovery_key,
+                create=lambda: tuple(
+                    self._session_factory.list_projects(
+                        credentials_path=credentials_path,
+                        quota_project_id=quota_project_id,
+                    )
+                ),
+            )
         )
+        return list(projects)
 
     def _project_discovery_cache_key(
         self, *, credentials_path: str | None, quota_project_id: str | None

--- a/src/anvil/providers/gcp/provider.py
+++ b/src/anvil/providers/gcp/provider.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from google.auth.credentials import Credentials
 
 from anvil.descriptors import TargetDescriptor
 from anvil.execution_context import ExecutionContext
@@ -121,7 +125,7 @@ class GcpSession:
 
     project_id: str
     location: str
-    credentials: object
+    credentials: Credentials
     quota_project_id: str | None = None
 
 
@@ -133,7 +137,7 @@ class GcpSessionFactory:
         *,
         credentials_path: str | None = None,
         quota_project_id: str | None = None,
-    ) -> object:
+    ) -> Credentials:
         try:
             import google.auth
         except ImportError as error:

--- a/src/anvil/providers/github/provider.py
+++ b/src/anvil/providers/github/provider.py
@@ -34,6 +34,7 @@ from anvil.providers.base import (
 )
 from anvil.provider_profiles import ProviderProfileConfig
 from anvil.results import ExecutionStatus
+from anvil.singleflight import SingleFlightCache
 
 __LOGGER__ = logging.getLogger(__name__)
 MODE_ORGANIZATIONS = "organizations"
@@ -101,66 +102,9 @@ class GithubRepository:
     owner: str | None = None
 
 
-@dataclass(slots=True)
-class _GithubRepositoryDiscoveryFlight:
-    event: threading.Event
-    repositories: list[GithubRepository] | None = None
-    error: BaseException | None = None
-
-
-class _GithubRepositoryDiscoveryCache:
-    """Single-flight cache for GitHub repository discovery."""
-
-    def __init__(self) -> None:
-        self._values: dict[object, list[GithubRepository]] = {}
-        self._flights: dict[object, _GithubRepositoryDiscoveryFlight] = {}
-        self._lock = threading.Lock()
-
-    def get_or_discover(
-        self, *, key: object, discover: Callable[[], list[GithubRepository]]
-    ) -> list[GithubRepository]:
-        with self._lock:
-            cached = self._values.get(key)
-            if cached is not None:
-                return list(cached)
-
-            flight = self._flights.get(key)
-            if flight is None:
-                flight = _GithubRepositoryDiscoveryFlight(event=threading.Event())
-                self._flights[key] = flight
-                owns_discovery = True
-            else:
-                owns_discovery = False
-
-        if owns_discovery:
-            try:
-                repositories = list(discover())
-            except BaseException as error:
-                with self._lock:
-                    flight.error = error
-                    self._flights.pop(key, None)
-                    flight.event.set()
-                raise
-
-            with self._lock:
-                cached = self._values.get(key)
-                stored = list(cached) if cached is not None else repositories
-                self._values[key] = list(stored)
-                flight.repositories = list(stored)
-                self._flights.pop(key, None)
-                flight.event.set()
-
-            return list(stored)
-
-        flight.event.wait()
-        if flight.error is not None:
-            raise flight.error
-        if flight.repositories is None:
-            raise RuntimeError("GitHub repository discovery completed empty")
-        return list(flight.repositories)
-
-
-_GITHUB_REPOSITORY_DISCOVERY_CACHE = _GithubRepositoryDiscoveryCache()
+_GITHUB_REPOSITORY_DISCOVERY_CACHE = SingleFlightCache[
+    object, tuple[GithubRepository, ...]
+]()
 
 
 @dataclass(slots=True)
@@ -1344,12 +1288,17 @@ class GithubProvider:
         discovery_key = self._repository_discovery_cache_key(
             owner_logins=owner_logins, provider_options=provider_options
         )
-        return _GITHUB_REPOSITORY_DISCOVERY_CACHE.get_or_discover(
-            key=discovery_key,
-            discover=lambda: self._session_factory.list_owner_repositories(
-                owner_logins=owner_logins, provider_options=provider_options
-            ),
+        repositories, _cache_hit, _cache_waited = (
+            _GITHUB_REPOSITORY_DISCOVERY_CACHE.get_or_create(
+                key=discovery_key,
+                create=lambda: tuple(
+                    self._session_factory.list_owner_repositories(
+                        owner_logins=owner_logins, provider_options=provider_options
+                    )
+                ),
+            )
         )
+        return list(repositories)
 
     def _repository_discovery_cache_key(
         self, *, owner_logins: list[str], provider_options: dict[str, object]

--- a/src/anvil/providers/github/tasks/_rest.py
+++ b/src/anvil/providers/github/tasks/_rest.py
@@ -16,56 +16,6 @@ class _GitHubRequester(Protocol):
     ) -> tuple[object, object]: ...
 
 
-def metadata_bool(
-    *, task_name: str, metadata: dict[str, object], key: str, default: bool
-) -> bool:
-    """Read a boolean task metadata value."""
-
-    value = metadata.get(key, default)
-    if not isinstance(value, bool):
-        raise RuntimeError(f"{task_name} metadata.{key} must be a boolean")
-    return value
-
-
-def metadata_int(
-    *,
-    task_name: str,
-    metadata: dict[str, object],
-    key: str,
-    default: int,
-    minimum: int = 1,
-    maximum: int | None = None,
-) -> int:
-    """Read a bounded integer task metadata value."""
-
-    value = metadata.get(key, default)
-    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
-        raise RuntimeError(
-            f"{task_name} metadata.{key} must be an integer greater than or equal "
-            f"to {minimum}"
-        )
-    if maximum is not None and value > maximum:
-        raise RuntimeError(
-            f"{task_name} metadata.{key} must be less than or equal to {maximum}"
-        )
-    return value
-
-
-def metadata_string(
-    *, task_name: str, metadata: dict[str, object], key: str, required: bool = False
-) -> str | None:
-    """Read an optional or required string task metadata value."""
-
-    value = metadata.get(key)
-    if value is None:
-        if required:
-            raise RuntimeError(f"{task_name} requires metadata.{key} to be a string")
-        return None
-    if not isinstance(value, str) or not value.strip():
-        raise RuntimeError(f"{task_name} metadata.{key} must be a non-empty string")
-    return value.strip()
-
-
 def metadata_params(
     *, task_name: str, metadata: dict[str, object], allowed_keys: tuple[str, ...]
 ) -> dict[str, object]:

--- a/src/anvil/providers/github/tasks/audit_branch_protection.py
+++ b/src/anvil/providers/github/tasks/audit_branch_protection.py
@@ -8,12 +8,12 @@ import logging
 
 from anvil.actions import ActionRecorder
 from anvil.providers.github.tasks._rest import (
-    metadata_string,
     require_github_provider,
     require_repository_target,
     rest_get,
     runtime_error_from_provider_error,
 )
+from anvil.providers.tasks._task_helpers import metadata_string
 
 __LOGGER__ = logging.getLogger(__name__)
 

--- a/src/anvil/providers/github/tasks/audit_rulesets.py
+++ b/src/anvil/providers/github/tasks/audit_rulesets.py
@@ -10,11 +10,10 @@ from anvil.actions import ActionRecorder
 from anvil.providers.github.tasks._rest import (
     DEFAULT_MAX_RESULTS,
     list_rest_items,
-    metadata_bool,
-    metadata_int,
     require_github_provider,
     require_repository_target,
 )
+from anvil.providers.tasks._task_helpers import metadata_bool, metadata_int
 
 __LOGGER__ = logging.getLogger(__name__)
 

--- a/src/anvil/providers/github/tasks/list_code_scanning_alert.py
+++ b/src/anvil/providers/github/tasks/list_code_scanning_alert.py
@@ -11,10 +11,10 @@ from anvil.providers.github.tasks._rest import (
     DEFAULT_MAX_RESULTS,
     alert_endpoint,
     list_rest_items,
-    metadata_int,
     metadata_params,
     require_github_provider,
 )
+from anvil.providers.tasks._task_helpers import metadata_int
 
 __LOGGER__ = logging.getLogger(__name__)
 

--- a/src/anvil/providers/github/tasks/list_dependabot_alert.py
+++ b/src/anvil/providers/github/tasks/list_dependabot_alert.py
@@ -11,10 +11,10 @@ from anvil.providers.github.tasks._rest import (
     DEFAULT_MAX_RESULTS,
     alert_endpoint,
     list_rest_items,
-    metadata_int,
     metadata_params,
     require_github_provider,
 )
+from anvil.providers.tasks._task_helpers import metadata_int
 
 __LOGGER__ = logging.getLogger(__name__)
 

--- a/src/anvil/providers/github/tasks/list_member.py
+++ b/src/anvil/providers/github/tasks/list_member.py
@@ -44,7 +44,9 @@ def run(
     operation = getattr(organization, "get_members", None)
     if not callable(operation):
         raise RuntimeError("list_member requires GitHub organization.get_members()")
-    maximum = metadata_int(metadata=metadata, key="max_results")
+    maximum = metadata_int(
+        task_name="list_member", metadata=metadata, key="max_results"
+    )
     members = [github_identity(item) for item in islice(operation(), maximum)]
     selectors = metadata_string_array(
         task_name="list_member", metadata=metadata, key="members"

--- a/src/anvil/providers/github/tasks/list_secret_scanning_alert.py
+++ b/src/anvil/providers/github/tasks/list_secret_scanning_alert.py
@@ -11,10 +11,10 @@ from anvil.providers.github.tasks._rest import (
     DEFAULT_MAX_RESULTS,
     alert_endpoint,
     list_rest_items,
-    metadata_int,
     metadata_params,
     require_github_provider,
 )
+from anvil.providers.tasks._task_helpers import metadata_int
 
 __LOGGER__ = logging.getLogger(__name__)
 

--- a/src/anvil/providers/github/tasks/list_team.py
+++ b/src/anvil/providers/github/tasks/list_team.py
@@ -44,7 +44,7 @@ def run(
     operation = getattr(organization, "get_teams", None)
     if not callable(operation):
         raise RuntimeError("list_team requires GitHub organization.get_teams()")
-    maximum = metadata_int(metadata=metadata, key="max_results")
+    maximum = metadata_int(task_name="list_team", metadata=metadata, key="max_results")
     teams = [github_identity(item) for item in islice(operation(), maximum)]
     selectors = metadata_string_array(
         task_name="list_team", metadata=metadata, key="teams"

--- a/src/anvil/providers/github/tasks/list_team_member.py
+++ b/src/anvil/providers/github/tasks/list_team_member.py
@@ -58,7 +58,9 @@ def run(
         for value in (getattr(team, "id", None), getattr(team, "slug", None))
         if value is not None
     }
-    maximum = metadata_int(metadata=metadata, key="max_results")
+    maximum = metadata_int(
+        task_name="list_team_member", metadata=metadata, key="max_results"
+    )
     selected_members = (
         {item.lower() for item in member_selectors}
         if member_selectors is not None

--- a/src/anvil/providers/github/tasks/search_code.py
+++ b/src/anvil/providers/github/tasks/search_code.py
@@ -9,10 +9,16 @@ from collections.abc import Iterable, Mapping
 from typing import Protocol, cast
 
 from anvil.actions import ActionRecorder
+from anvil.providers.tasks._task_helpers import (
+    metadata_bool,
+    metadata_int,
+    metadata_string,
+)
 
 __LOGGER__ = logging.getLogger(__name__)
 
 DEFAULT_MAX_RESULTS = 100
+TASK_NAME = "search_code"
 
 
 class _SearchClient(Protocol):
@@ -21,35 +27,6 @@ class _SearchClient(Protocol):
     def search_code(
         self, query: str, *, highlight: bool = False
     ) -> Iterable[object]: ...
-
-
-def _metadata_string(
-    *, metadata: dict[str, object], key: str, required: bool = False
-) -> str | None:
-    value = metadata.get(key)
-    if value is None:
-        if required:
-            raise RuntimeError(f"search_code requires metadata.{key} to be a string")
-        return None
-    if not isinstance(value, str) or not value.strip():
-        raise RuntimeError(f"search_code metadata.{key} must be a non-empty string")
-    return value.strip()
-
-
-def _metadata_max_results(*, metadata: dict[str, object]) -> int:
-    value = metadata.get("max_results", DEFAULT_MAX_RESULTS)
-    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
-        raise RuntimeError(
-            "search_code metadata.max_results must be a positive integer"
-        )
-    return value
-
-
-def _metadata_highlight(*, metadata: dict[str, object]) -> bool:
-    value = metadata.get("highlight", False)
-    if not isinstance(value, bool):
-        raise RuntimeError("search_code metadata.highlight must be a boolean")
-    return value
 
 
 def _quote_qualifier_value(value: str) -> str:
@@ -61,7 +38,9 @@ def _quote_qualifier_value(value: str) -> str:
 def _query(
     *, metadata: dict[str, object], execution_target_id: str, execution_target_type: str
 ) -> str:
-    query = _metadata_string(metadata=metadata, key="query", required=True)
+    query = metadata_string(
+        task_name=TASK_NAME, metadata=metadata, key="query", required=True
+    )
     qualifiers: list[str] = []
 
     if execution_target_type == "organization":
@@ -79,11 +58,11 @@ def _query(
         ("extension", "extension"),
         ("filename", "filename"),
     ):
-        value = _metadata_string(metadata=metadata, key=key)
+        value = metadata_string(task_name=TASK_NAME, metadata=metadata, key=key)
         if value is not None:
             qualifiers.append(f"{qualifier}:{_quote_qualifier_value(value)}")
 
-    return " ".join([query or "", *qualifiers])
+    return " ".join([query, *qualifiers])
 
 
 def _get_value(item: object, key: str) -> object:
@@ -247,8 +226,15 @@ def run(
         execution_target_id=execution_target_id,
         execution_target_type=execution_target_type,
     )
-    max_results = _metadata_max_results(metadata=metadata)
-    highlight = _metadata_highlight(metadata=metadata)
+    max_results = metadata_int(
+        task_name=TASK_NAME,
+        metadata=metadata,
+        key="max_results",
+        default=DEFAULT_MAX_RESULTS,
+    )
+    highlight = metadata_bool(
+        task_name=TASK_NAME, metadata=metadata, key="highlight", default=False
+    )
 
     try:
         search_results = _search_client(session).search_code(query, highlight=highlight)

--- a/src/anvil/providers/gitlab/tasks/_api.py
+++ b/src/anvil/providers/gitlab/tasks/_api.py
@@ -36,13 +36,17 @@ def project_for_task(
 
 
 def list_manager(
-    *, manager: object, metadata: dict[str, object], **parameters: object
+    *,
+    task_name: str,
+    manager: object,
+    metadata: dict[str, object],
+    **parameters: object,
 ) -> list[object]:
     """List a bounded python-gitlab manager collection."""
     operation = getattr(manager, "list", None)
     if not callable(operation):
         raise RuntimeError("python-gitlab manager does not expose list()")
-    maximum = metadata_int(metadata=metadata, key="max_results")
+    maximum = metadata_int(task_name=task_name, metadata=metadata, key="max_results")
     return bounded(operation(iterator=True, **parameters), max_results=maximum)
 
 
@@ -74,6 +78,7 @@ def list_vulnerability_alerts(
                 )
             parameters[key] = value.strip()
     return list_manager(
+        task_name=task_name,
         manager=getattr(project, "vulnerabilities", None),
         metadata=metadata,
         **parameters,

--- a/src/anvil/providers/gitlab/tasks/_membership.py
+++ b/src/anvil/providers/gitlab/tasks/_membership.py
@@ -30,7 +30,9 @@ def member_manager(resource: object) -> object:
     return getattr(resource, "members_all", None) or getattr(resource, "members", None)
 
 
-def list_members(*, resource: object, metadata: dict[str, object]) -> list[object]:
+def list_members(
+    *, task_name: str, resource: object, metadata: dict[str, object]
+) -> list[object]:
     """List bounded GitLab group or project membership records."""
 
     manager = member_manager(resource)
@@ -39,5 +41,7 @@ def list_members(*, resource: object, metadata: dict[str, object]) -> list[objec
         raise RuntimeError("GitLab resource does not expose a member list operation")
     return bounded(
         operation(iterator=True),
-        max_results=metadata_int(metadata=metadata, key="max_results"),
+        max_results=metadata_int(
+            task_name=task_name, metadata=metadata, key="max_results"
+        ),
     )

--- a/src/anvil/providers/gitlab/tasks/audit_branch_protection.py
+++ b/src/anvil/providers/gitlab/tasks/audit_branch_protection.py
@@ -37,7 +37,9 @@ def run(
         session=session,
     )
     rules = list_manager(
-        manager=getattr(project, "protectedbranches", None), metadata=metadata
+        task_name="audit_branch_protection",
+        manager=getattr(project, "protectedbranches", None),
+        metadata=metadata,
     )
     __LOGGER__.info(
         f"Audited {len(rules)} GitLab protected branch rule(s) for {execution_target_name}"

--- a/src/anvil/providers/gitlab/tasks/audit_rulesets.py
+++ b/src/anvil/providers/gitlab/tasks/audit_rulesets.py
@@ -38,11 +38,15 @@ def run(
         session=session,
     )
     protected = list_manager(
-        manager=getattr(project, "protectedbranches", None), metadata=metadata
+        task_name="audit_rulesets",
+        manager=getattr(project, "protectedbranches", None),
+        metadata=metadata,
     )
     approvals_manager = getattr(project, "approvalrules", None)
     approvals = (
-        list_manager(manager=approvals_manager, metadata=metadata)
+        list_manager(
+            task_name="audit_rulesets", manager=approvals_manager, metadata=metadata
+        )
         if approvals_manager is not None
         else []
     )

--- a/src/anvil/providers/gitlab/tasks/list_member.py
+++ b/src/anvil/providers/gitlab/tasks/list_member.py
@@ -40,7 +40,9 @@ def run(
         execution_target_type=execution_target_type,
         session=session,
     )
-    members = list_members(resource=resource, metadata=metadata)
+    members = list_members(
+        task_name="list_member", resource=resource, metadata=metadata
+    )
     selectors = metadata_string_array(
         task_name="list_member", metadata=metadata, key="members"
     )

--- a/src/anvil/providers/gitlab/tasks/search_code.py
+++ b/src/anvil/providers/gitlab/tasks/search_code.py
@@ -41,7 +41,9 @@ def run(
         execution_target_type=execution_target_type,
         session=session,
     )
-    maximum = metadata_int(metadata=metadata, key="max_results")
+    maximum = metadata_int(
+        task_name="search_code", metadata=metadata, key="max_results"
+    )
     matches = bounded(
         project.search("blobs", query, iterator=True), max_results=maximum
     )

--- a/src/anvil/providers/pagerduty/tasks/_rest.py
+++ b/src/anvil/providers/pagerduty/tasks/_rest.py
@@ -4,11 +4,13 @@ from anvil.providers.tasks._task_helpers import bounded, metadata_int
 
 
 def list_resources(
-    *, session, resource: str, metadata: dict[str, object]
+    *, task_name: str, session, resource: str, metadata: dict[str, object]
 ) -> list[object]:
     """List a bounded PagerDuty REST collection."""
 
-    max_results = metadata_int(metadata=metadata, key="max_results")
+    max_results = metadata_int(
+        task_name=task_name, metadata=metadata, key="max_results"
+    )
     iterator = getattr(session.client, "iter_all", None)
     if not callable(iterator):
         raise RuntimeError("PagerDuty client does not expose iter_all()")

--- a/src/anvil/providers/pagerduty/tasks/list_escalation_policy.py
+++ b/src/anvil/providers/pagerduty/tasks/list_escalation_policy.py
@@ -34,7 +34,10 @@ def run(
         task_name="list_escalation_policy", provider=provider, expected="pagerduty"
     )
     items = list_resources(
-        session=session, resource="escalation_policies", metadata=metadata
+        task_name="list_escalation_policy",
+        session=session,
+        resource="escalation_policies",
+        metadata=metadata,
     )
     __LOGGER__.info(
         f"Listed {len(items)} PagerDuty escalation policy/policies for {execution_target_name}"

--- a/src/anvil/providers/pagerduty/tasks/list_service.py
+++ b/src/anvil/providers/pagerduty/tasks/list_service.py
@@ -31,7 +31,12 @@ def run(
         Service count and JSON-serializable services.
     """
     require_provider(task_name="list_service", provider=provider, expected="pagerduty")
-    items = list_resources(session=session, resource="services", metadata=metadata)
+    items = list_resources(
+        task_name="list_service",
+        session=session,
+        resource="services",
+        metadata=metadata,
+    )
     __LOGGER__.info(
         f"Listed {len(items)} PagerDuty service(s) for {execution_target_name}"
     )

--- a/src/anvil/providers/pagerduty/tasks/list_team.py
+++ b/src/anvil/providers/pagerduty/tasks/list_team.py
@@ -31,7 +31,9 @@ def run(
         Team count and JSON-serializable teams.
     """
     require_provider(task_name="list_team", provider=provider, expected="pagerduty")
-    items = list_resources(session=session, resource="teams", metadata=metadata)
+    items = list_resources(
+        task_name="list_team", session=session, resource="teams", metadata=metadata
+    )
     __LOGGER__.info(
         f"Listed {len(items)} PagerDuty team(s) for {execution_target_name}"
     )

--- a/src/anvil/providers/pagerduty/tasks/list_user.py
+++ b/src/anvil/providers/pagerduty/tasks/list_user.py
@@ -44,7 +44,9 @@ def run(
     selectors = metadata_string_array(
         task_name="list_user", metadata=metadata, key="users"
     )
-    users = list_resources(session=session, resource="users", metadata=metadata)
+    users = list_resources(
+        task_name="list_user", session=session, resource="users", metadata=metadata
+    )
     if selectors is None:
         matched = users
         unmatched: list[str] = []

--- a/src/anvil/providers/tasks/_task_helpers.py
+++ b/src/anvil/providers/tasks/_task_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from enum import Enum
+from typing import Literal, overload
 
 DEFAULT_MAX_RESULTS = 1_000
 
@@ -24,19 +25,59 @@ def require_target_type(
         raise RuntimeError(f"{task_name} requires a {expected} target")
 
 
-def metadata_int(
-    *, metadata: dict[str, object], key: str, default: int = DEFAULT_MAX_RESULTS
-) -> int:
-    """Return a positive integer metadata value."""
+def metadata_bool(
+    *, task_name: str, metadata: Mapping[str, object], key: str, default: bool
+) -> bool:
+    """Return a boolean metadata value."""
 
     value = metadata.get(key, default)
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-        raise RuntimeError(f"metadata.{key} must be a positive integer")
+    if not isinstance(value, bool):
+        raise RuntimeError(f"{task_name} metadata.{key} must be a boolean")
     return value
 
 
+def metadata_int(
+    *,
+    task_name: str,
+    metadata: Mapping[str, object],
+    key: str,
+    default: int = DEFAULT_MAX_RESULTS,
+    minimum: int = 1,
+    maximum: int | None = None,
+) -> int:
+    """Return a bounded integer metadata value."""
+
+    value = metadata.get(key, default)
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        raise RuntimeError(
+            f"{task_name} metadata.{key} must be an integer greater than or equal "
+            f"to {minimum}"
+        )
+    if maximum is not None and value > maximum:
+        raise RuntimeError(
+            f"{task_name} metadata.{key} must be less than or equal to {maximum}"
+        )
+    return value
+
+
+@overload
 def metadata_string(
-    *, task_name: str, metadata: dict[str, object], key: str, required: bool = False
+    *, task_name: str, metadata: Mapping[str, object], key: str, required: Literal[True]
+) -> str: ...
+
+
+@overload
+def metadata_string(
+    *,
+    task_name: str,
+    metadata: Mapping[str, object],
+    key: str,
+    required: Literal[False] = False,
+) -> str | None: ...
+
+
+def metadata_string(
+    *, task_name: str, metadata: Mapping[str, object], key: str, required: bool = False
 ) -> str | None:
     """Return a normalized optional or required string metadata value."""
 
@@ -51,8 +92,24 @@ def metadata_string(
     return value.strip()
 
 
+@overload
 def metadata_string_array(
-    *, task_name: str, metadata: dict[str, object], key: str, required: bool = False
+    *, task_name: str, metadata: Mapping[str, object], key: str, required: Literal[True]
+) -> list[str]: ...
+
+
+@overload
+def metadata_string_array(
+    *,
+    task_name: str,
+    metadata: Mapping[str, object],
+    key: str,
+    required: Literal[False] = False,
+) -> list[str] | None: ...
+
+
+def metadata_string_array(
+    *, task_name: str, metadata: Mapping[str, object], key: str, required: bool = False
 ) -> list[str] | None:
     """Return a normalized array of unique non-empty string selectors."""
 

--- a/src/anvil/runner.py
+++ b/src/anvil/runner.py
@@ -1985,21 +1985,28 @@ def _run_target_pipeline(
             ThreadPoolExecutor(max_workers=worker_limit) as prepare_executor,
             ThreadPoolExecutor(max_workers=worker_limit) as execute_executor,
         ):
-            preflight_futures: dict[Future[PreparedTarget], int] = {
-                prepare_executor.submit(
-                    prepare_target,
-                    index=index,
-                    target=target,
-                    cli_dry_run=cli_dry_run,
-                    cli_include=cli_include,
-                    cli_exclude=cli_exclude,
-                    preparation_cache=preparation_cache,
-                    auth_cache=auth_cache,
-                    benchmark_enabled=benchmark_enabled,
+            preflight_futures: dict[
+                Future[PreparedTarget | TargetExecutionOutcome], int
+            ] = {
+                cast(
+                    Future[PreparedTarget | TargetExecutionOutcome],
+                    prepare_executor.submit(
+                        prepare_target,
+                        index=index,
+                        target=target,
+                        cli_dry_run=cli_dry_run,
+                        cli_include=cli_include,
+                        cli_exclude=cli_exclude,
+                        preparation_cache=preparation_cache,
+                        auth_cache=auth_cache,
+                        benchmark_enabled=benchmark_enabled,
+                    ),
                 ): index
                 for index, target in enumerate(targets)
             }
-            execution_futures: dict[Future[TargetExecutionOutcome], PreparedTarget] = {}
+            execution_futures: dict[
+                Future[PreparedTarget | TargetExecutionOutcome], PreparedTarget
+            ] = {}
 
             # This loop coordinates two concurrent flows:
             # - preflight futures prepare targets and record auth results in input order
@@ -2014,8 +2021,11 @@ def _run_target_pipeline(
                     if next_target is None:
                         break
 
-                    future = execute_executor.submit(
-                        run_prepared_target, prepared_target=next_target
+                    future = cast(
+                        Future[PreparedTarget | TargetExecutionOutcome],
+                        execute_executor.submit(
+                            run_prepared_target, prepared_target=next_target
+                        ),
                     )
                     execution_futures[future] = next_target
 
@@ -2030,7 +2040,12 @@ def _run_target_pipeline(
                 done, _ = wait(waited_futures, return_when=FIRST_COMPLETED)
                 for future in done:
                     if future in preflight_futures:
-                        prepared_target = future.result()
+                        prepared_result = future.result()
+                        if not isinstance(prepared_result, PreparedTarget):
+                            raise TypeError(
+                                "target preparation returned an execution outcome"
+                            )
+                        prepared_target = prepared_result
                         auth_results_by_index[prepared_target.index] = (
                             prepared_target.auth_result
                         )
@@ -2046,6 +2061,8 @@ def _run_target_pipeline(
                     )
 
                     outcome = future.result()
+                    if not isinstance(outcome, TargetExecutionOutcome):
+                        raise TypeError("target execution returned a prepared target")
                     target_results_by_index[outcome.index] = outcome.target_result
 
                     if outcome.target_result.has_failures:

--- a/src/anvil/runner.py
+++ b/src/anvil/runner.py
@@ -13,7 +13,7 @@ from concurrent.futures import (
     ThreadPoolExecutor,
     wait,
 )
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, replace
 from typing import cast
 
 from anvil.benchmark import BenchmarkRecorder
@@ -41,6 +41,7 @@ from anvil.results import (
     TaskResult,
     aggregate_execution_statuses,
 )
+from anvil.singleflight import SingleFlightCache
 from anvil.task_context import (
     TaskCallContext,
     merge_task_metadata,
@@ -79,64 +80,6 @@ _SESSION_NOT_CREATED = object()
 
 def _load_provider(provider_name: str) -> Provider:
     return load_provider(provider_name)
-
-
-@dataclass(slots=True)
-class _SingleFlightEntry:
-    event: threading.Event = field(default_factory=threading.Event)
-    value: object | None = None
-    error: BaseException | None = None
-
-
-class _SingleFlightCache:
-    def __init__(self) -> None:
-        self._values: dict[object, object] = {}
-        self._flights: dict[object, _SingleFlightEntry] = {}
-        self._lock = threading.Lock()
-
-    def get_or_create(
-        self, *, key: object, create: Callable[[], object]
-    ) -> tuple[object, bool, bool]:
-        with self._lock:
-            existing = self._values.get(key)
-            if existing is not None:
-                return existing, True, False
-
-            flight = self._flights.get(key)
-            if flight is None:
-                flight = _SingleFlightEntry()
-                self._flights[key] = flight
-                owns_create = True
-            else:
-                owns_create = False
-
-        if owns_create:
-            try:
-                value = create()
-            except BaseException as error:
-                with self._lock:
-                    flight.error = error
-                    self._flights.pop(key, None)
-                    flight.event.set()
-                raise
-
-            with self._lock:
-                existing = self._values.get(key)
-                cached_value = existing if existing is not None else value
-                self._values[key] = cached_value
-                flight.value = cached_value
-                self._flights.pop(key, None)
-                flight.event.set()
-
-            return cached_value, False, False
-
-        flight.event.wait()
-        if flight.error is not None:
-            raise flight.error
-        if flight.value is None:
-            raise RuntimeError("Single-flight cache entry completed empty")
-
-        return flight.value, True, True
 
 
 @dataclass(frozen=True, slots=True)
@@ -185,7 +128,7 @@ class _AuthCheckCacheLookup:
 
 class AuthCheckCache:
     def __init__(self) -> None:
-        self._cache = _SingleFlightCache()
+        self._cache = SingleFlightCache[object, AuthCheckOutcome]()
 
     def get_or_check(
         self, *, key: object, check: Callable[[], AuthCheckOutcome]
@@ -383,7 +326,7 @@ def prepare_target(
     cli_dry_run: bool | None,
     cli_include: list[str] | None,
     cli_exclude: list[str] | None,
-    preparation_cache: _SingleFlightCache,
+    preparation_cache: SingleFlightCache[object, object],
     auth_cache: AuthCheckCache,
     benchmark_enabled: bool = False,
 ) -> PreparedTarget:
@@ -1349,8 +1292,8 @@ def _execute_provider_task_graph(
             for instance in plan.instances
         ),
     )
-    runtime_cache = _SingleFlightCache()
-    session_cache = _SingleFlightCache()
+    runtime_cache = SingleFlightCache[object, object]()
+    session_cache = SingleFlightCache[object, object]()
     created_runtimes: dict[tuple[bool, str], ProviderExecutionRuntime] = {}
     created_sessions: set[tuple[bool, str, str]] = set()
     runtime_benchmarks: dict[tuple[bool, str], dict[str, object]] = {}
@@ -1975,7 +1918,7 @@ def _run_target_pipeline(
     # same-organization exclusion has cleared.
     ready_targets: deque[PreparedTarget] = deque()
     active_execution_keys: set[object] = set()
-    preparation_cache = _SingleFlightCache()
+    preparation_cache = SingleFlightCache[object, object]()
     auth_cache = AuthCheckCache()
 
     if targets:

--- a/src/anvil/singleflight.py
+++ b/src/anvil/singleflight.py
@@ -1,0 +1,85 @@
+"""Thread-safe cache that coalesces concurrent work for the same key."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Generic, TypeVar, cast
+
+KeyT = TypeVar("KeyT")
+ValueT = TypeVar("ValueT")
+
+_MISSING = object()
+
+
+@dataclass(slots=True)
+class _SingleFlightEntry(Generic[ValueT]):
+    """State shared by callers waiting for one in-flight computation."""
+
+    event: threading.Event = field(default_factory=threading.Event)
+    value: object = _MISSING
+    error: BaseException | None = None
+
+
+class SingleFlightCache(Generic[KeyT, ValueT]):
+    """Cache completed values and share concurrent work for matching keys."""
+
+    def __init__(self) -> None:
+        self._values: dict[KeyT, ValueT] = {}
+        self._flights: dict[KeyT, _SingleFlightEntry[ValueT]] = {}
+        self._lock = threading.Lock()
+
+    def get_or_create(
+        self, *, key: KeyT, create: Callable[[], ValueT]
+    ) -> tuple[ValueT, bool, bool]:
+        """Return a cached value or create it once for concurrent callers.
+
+        Args:
+            key: Cache identity for the requested value.
+            create: Callback used by the first caller when the key is absent.
+
+        Returns:
+            A tuple containing the value, whether it came from shared cache
+            state, and whether this caller waited for an in-flight creator.
+
+        Raises:
+            BaseException: Re-raises any failure from the creator for the owner
+                and every caller waiting on that flight.
+        """
+
+        with self._lock:
+            if key in self._values:
+                return self._values[key], True, False
+
+            flight = self._flights.get(key)
+            if flight is None:
+                flight = _SingleFlightEntry[ValueT]()
+                self._flights[key] = flight
+                owns_create = True
+            else:
+                owns_create = False
+
+        if owns_create:
+            try:
+                value = create()
+            except BaseException as error:
+                with self._lock:
+                    flight.error = error
+                    self._flights.pop(key, None)
+                    flight.event.set()
+                raise
+
+            with self._lock:
+                self._values[key] = value
+                flight.value = value
+                self._flights.pop(key, None)
+                flight.event.set()
+            return value, False, False
+
+        flight.event.wait()
+        if flight.error is not None:
+            raise flight.error
+        if flight.value is _MISSING:
+            raise RuntimeError("Single-flight cache entry completed without a value")
+        return cast("ValueT", flight.value), True, True

--- a/tests/providers/aws/test_task_implementations.py
+++ b/tests/providers/aws/test_task_implementations.py
@@ -8,8 +8,13 @@ from botocore.exceptions import ClientError
 
 from anvil.actions import ActionRecorder
 from anvil.providers.aws.tasks import compare_asg_to_cluster_instances
+from anvil.providers.aws.tasks import get_aws_inline_policies
+from anvil.providers.aws.tasks import get_aws_sso_inline_policies
+from anvil.providers.aws.tasks import get_organization_structure
 from anvil.providers.aws.tasks import remove_iam_user
+from anvil.providers.aws.tasks import remove_idc_user
 from anvil.providers.aws.tasks import remove_missing_group_assignments
+from anvil.task_errors import TaskExecutionError
 
 
 def _client_error(code: str, operation_name: str) -> ClientError:
@@ -79,8 +84,14 @@ def test_group_validation_surfaces_unexpected_client_errors() -> None:
 
 
 class FakeSsoAdminClient:
-    def __init__(self, *, delete_error: ClientError | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        delete_error: ClientError | None = None,
+        deletion_status: str = "SUCCEEDED",
+    ) -> None:
         self.delete_error = delete_error
+        self.deletion_status = deletion_status
         self.delete_calls: list[dict[str, object]] = []
 
     def list_instances(self) -> dict[str, object]:
@@ -95,10 +106,17 @@ class FakeSsoAdminClient:
             ]
         }
 
-    def delete_account_assignment(self, **kwargs: object) -> None:
+    def delete_account_assignment(self, **kwargs: object) -> dict[str, object]:
         self.delete_calls.append(kwargs)
         if self.delete_error is not None:
             raise self.delete_error
+        return {
+            "AccountAssignmentDeletionStatus": {
+                "Status": self.deletion_status,
+                "RequestId": "request-1",
+                "FailureReason": "test failure",
+            }
+        }
 
 
 def _run_remove_missing_group_assignments(
@@ -106,6 +124,7 @@ def _run_remove_missing_group_assignments(
     *,
     dry_run: bool,
     delete_error: ClientError | None = None,
+    deletion_status: str = "SUCCEEDED",
 ) -> tuple[dict[str, object], list[str], FakeSsoAdminClient]:
     assignment = {
         "PermissionSetArn": "arn:aws:sso:::permissionSet/ssoins-1/ps-1",
@@ -133,7 +152,9 @@ def _run_remove_missing_group_assignments(
         lambda *_args: {"group-1": False},
     )
 
-    sso_admin_client = FakeSsoAdminClient(delete_error=delete_error)
+    sso_admin_client = FakeSsoAdminClient(
+        delete_error=delete_error, deletion_status=deletion_status
+    )
     session = FakeSession(
         {
             "sso-admin": sso_admin_client,
@@ -183,6 +204,31 @@ def test_remove_missing_group_assignments_surfaces_delete_failure(
     assert raised.value is error
 
 
+def test_remove_missing_group_assignments_waits_for_terminal_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, actions, client = _run_remove_missing_group_assignments(
+        monkeypatch, dry_run=False
+    )
+
+    assert result["removed_count"] == 1
+    assert result["failed_count"] == 0
+    assert len(client.delete_calls) == 1
+    assert actions == ["Removed 1 missing group assignment(s)"]
+
+
+def test_remove_missing_group_assignments_preserves_failed_status_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(TaskExecutionError) as raised:
+        _run_remove_missing_group_assignments(
+            monkeypatch, dry_run=False, deletion_status="FAILED"
+        )
+
+    assert raised.value.partial_result["failed_count"] == 1
+    assert raised.value.partial_result["removed_count"] == 0
+
+
 class FakeIamClient:
     def __init__(self) -> None:
         self.paginators = {
@@ -207,6 +253,9 @@ class FakeIamClient:
     def get_paginator(self, operation_name: str) -> FakePaginator:
         return self.paginators[operation_name]
 
+    def get_user(self, **_kwargs: object) -> dict[str, object]:
+        return {"User": {"UserName": "alice"}}
+
     def list_service_specific_credentials(self, **_kwargs: object) -> dict[str, object]:
         return {"ServiceSpecificCredentials": []}
 
@@ -219,11 +268,16 @@ class FakeIamClient:
     def delete_access_key(self, **kwargs: object) -> None:
         self.mutation_calls.append(("delete_access_key", kwargs))
 
+    def delete_user(self, **kwargs: object) -> None:
+        self.mutation_calls.append(("delete_user", kwargs))
 
-def _run_remove_iam_user(*, dry_run: bool) -> tuple[list[str], FakeIamClient]:
+
+def _run_remove_iam_user(
+    *, dry_run: bool, metadata: dict[str, object] | None = None
+) -> tuple[dict[str, object], list[str], FakeIamClient]:
     iam_client = FakeIamClient()
     actions = ActionRecorder(actions=[])
-    remove_iam_user.run(
+    result = remove_iam_user.run(
         provider="aws",
         execution_target_id="111111111111",
         execution_target_name="workload",
@@ -231,33 +285,43 @@ def _run_remove_iam_user(*, dry_run: bool) -> tuple[list[str], FakeIamClient]:
         region="us-east-1",
         session=FakeSession({"iam": iam_client}),
         dry_run=dry_run,
-        metadata={"user_name": "alice"},
+        metadata=metadata if metadata is not None else {"users": ["alice"]},
         dependency_data={},
         actions=actions,
     )
-    return actions.actions, iam_client
+    return result, actions.actions, iam_client
 
 
 def test_remove_iam_user_cleans_resources_from_every_page() -> None:
-    actions, client = _run_remove_iam_user(dry_run=False)
+    result, actions, client = _run_remove_iam_user(dry_run=False)
 
     assert client.mutation_calls == [
         ("remove_user_from_group", {"GroupName": "group-a", "UserName": "alice"}),
         ("delete_access_key", {"UserName": "alice", "AccessKeyId": "key-a"}),
         ("delete_access_key", {"UserName": "alice", "AccessKeyId": "key-b"}),
+        ("delete_user", {"UserName": "alice"}),
     ]
     assert all(
         paginator.calls == [{"UserName": "alice"}]
         for paginator in client.paginators.values()
     )
-    assert actions == ["Removed IAM user resources for alice"]
+    assert result["removed_count"] == 1
+    assert actions == ["Removed 1 IAM user(s)"]
 
 
 def test_remove_iam_user_labels_dry_run_and_does_not_mutate() -> None:
-    actions, client = _run_remove_iam_user(dry_run=True)
+    result, actions, client = _run_remove_iam_user(
+        dry_run=True, metadata={"users": ["alice"]}
+    )
 
     assert client.mutation_calls == []
-    assert actions == ["(dry-run) Would remove IAM user resources for alice"]
+    assert result["planned_count"] == 1
+    assert actions == ["(dry-run) Would remove 1 IAM user(s)"]
+
+
+def test_remove_iam_user_rejects_legacy_user_name_selector() -> None:
+    with pytest.raises(RuntimeError, match=r"metadata\.users"):
+        _run_remove_iam_user(dry_run=True, metadata={"user_name": "alice"})
 
 
 class FakeAutoScalingClient:
@@ -298,7 +362,7 @@ def test_compare_asg_to_cluster_instances_reads_every_ecs_page() -> None:
     ecs_client = FakeEcsClient()
     actions = ActionRecorder(actions=[])
 
-    compare_asg_to_cluster_instances.run(
+    result = compare_asg_to_cluster_instances.run(
         provider="aws",
         execution_target_id="111111111111",
         execution_target_name="workload",
@@ -319,3 +383,133 @@ def test_compare_asg_to_cluster_instances_reads_every_ecs_page() -> None:
         {"cluster": "api", "containerInstances": ["arn:container/b"]},
     ]
     assert actions.actions == ["Completed ASG vs ECS comparison for 1 clusters"]
+    assert result["missing_from_asg_count"] == 0
+    assert result["zero_task_instance_count"] == 0
+
+
+class FakeZeroTaskEcsClient(FakeEcsClient):
+    def describe_container_instances(self, **kwargs: object) -> dict[str, object]:
+        self.describe_calls.append(kwargs)
+        return {
+            "containerInstances": [
+                {"ec2InstanceId": "i-outside-asg", "runningTasksCount": 0}
+            ]
+        }
+
+
+def test_compare_asg_reports_missing_and_zero_task_instances_together() -> None:
+    ecs_client = FakeZeroTaskEcsClient()
+    result = compare_asg_to_cluster_instances.run(
+        provider="aws",
+        execution_target_id="111111111111",
+        execution_target_name="workload",
+        execution_target_type="account",
+        region="us-east-1",
+        session=FakeSession(
+            {"autoscaling": FakeAutoScalingClient(), "ecs": ecs_client}
+        ),
+        dry_run=False,
+        metadata={"clusters": ["api"]},
+        dependency_data={},
+        actions=ActionRecorder(actions=[]),
+    )
+
+    assert result["missing_from_asg_count"] == 1
+    assert result["zero_task_instance_count"] == 1
+    assert result["clusters"][0]["instances_missing_from_asg"] == ["i-outside-asg"]
+    assert result["clusters"][0]["instances_with_zero_tasks"] == ["i-outside-asg"]
+
+
+class FakeIamPolicyClient:
+    def __init__(self, *, policy_error: ClientError | None = None) -> None:
+        self.policy_error = policy_error
+
+    def get_paginator(self, operation_name: str) -> FakePaginator:
+        pages = {
+            "list_users": [{"Users": [{"UserName": "alice"}]}],
+            "list_user_policies": [{"PolicyNames": ["inline-a"]}],
+        }
+        return FakePaginator(pages[operation_name])
+
+    def get_user_policy(self, **_kwargs: object) -> dict[str, object]:
+        if self.policy_error is not None:
+            raise self.policy_error
+        return {"PolicyDocument": {"Version": "2012-10-17", "Statement": []}}
+
+
+def _run_inline_policy_inventory(client: FakeIamPolicyClient) -> dict[str, object]:
+    return get_aws_inline_policies.run(
+        provider="aws",
+        execution_target_id="111111111111",
+        execution_target_name="workload",
+        execution_target_type="account",
+        region="us-east-1",
+        session=FakeSession({"iam": client}),
+        dry_run=False,
+        metadata={"types": ["user"]},
+        dependency_data={},
+        actions=ActionRecorder(actions=[]),
+    )
+
+
+def test_inline_policy_inventory_returns_collected_policies() -> None:
+    result = _run_inline_policy_inventory(FakeIamPolicyClient())
+
+    assert result["policy_count"] == 1
+    assert result["error_count"] == 0
+
+
+def test_inline_policy_inventory_preserves_partial_failures() -> None:
+    with pytest.raises(TaskExecutionError) as raised:
+        _run_inline_policy_inventory(
+            FakeIamPolicyClient(
+                policy_error=_client_error("AccessDenied", "GetUserPolicy")
+            )
+        )
+
+    assert raised.value.partial_result["policy_count"] == 0
+    assert raised.value.partial_result["error_count"] == 1
+
+
+@pytest.mark.parametrize(
+    ("task_module", "expected_scope"),
+    [
+        (remove_iam_user, "target"),
+        (get_aws_inline_policies, "target"),
+        (remove_idc_user, "configured_target"),
+        (remove_missing_group_assignments, "configured_target"),
+        (get_organization_structure, "configured_target"),
+        (get_aws_sso_inline_policies, "configured_target"),
+    ],
+)
+def test_account_wide_aws_tasks_run_once_per_intended_boundary(
+    task_module, expected_scope: str
+) -> None:
+    assert task_module.TASK_SCOPE == expected_scope
+
+
+class FakeOrganizationClient:
+    def get_paginator(self, operation_name: str):
+        assert operation_name == "list_organizational_units_for_parent"
+        return self
+
+    def paginate(self, **kwargs: object):
+        parent_id = kwargs["ParentId"]
+        assert isinstance(parent_id, str)
+        children = {
+            "r-root": [{"Id": "ou-parent", "Name": "Parent"}],
+            "ou-parent": [{"Id": "ou-child", "Name": "Child"}],
+            "ou-child": [],
+        }
+        yield {"OrganizationalUnits": children[parent_id]}
+
+
+def test_organization_discovery_recurses_and_preserves_parents() -> None:
+    result = get_organization_structure._list_all_organizational_units(
+        "r-root", FakeOrganizationClient()
+    )
+
+    assert result == [
+        {"Id": "ou-parent", "Name": "Parent", "ParentId": "r-root"},
+        {"Id": "ou-child", "Name": "Child", "ParentId": "ou-parent"},
+    ]

--- a/tests/providers/cloudflare/test_cloudflare_provider.py
+++ b/tests/providers/cloudflare/test_cloudflare_provider.py
@@ -28,7 +28,8 @@ from anvil.providers.cloudflare.session import (
     CloudflareZone,
 )
 from anvil.results import EngineState, ExecutionStatus
-from anvil.runner import _SingleFlightCache, run_multiple_targets
+from anvil.runner import run_multiple_targets
+from anvil.singleflight import SingleFlightCache
 from anvil.task_context import TaskCallContext
 from anvil.task_loader import ResolvedExecution, ResolvedTask
 
@@ -332,7 +333,7 @@ def test_cloudflare_discovery_filter_reports_unknown_exclusions():
             context=_context(),
             include=None,
             exclude=["c" * 32],
-            cache=_SingleFlightCache(),
+            cache=SingleFlightCache(),
             benchmark=None,
         )
 
@@ -366,7 +367,7 @@ def test_cloudflare_account_preflight_discovers_sorts_excludes_and_keys():
         context=_context(),
         include=None,
         exclude=target.exclude,
-        cache=_SingleFlightCache(),
+        cache=SingleFlightCache(),
         benchmark=benchmark,
     )
 
@@ -391,7 +392,7 @@ def test_cloudflare_zone_preflight_bounds_discovery_and_preserves_parent_metadat
         context=_context(),
         include=None,
         exclude=None,
-        cache=_SingleFlightCache(),
+        cache=SingleFlightCache(),
         benchmark=None,
     )
     plan = provider.resolve_execution_targets(
@@ -420,7 +421,7 @@ def test_cloudflare_preflight_reuses_cache_and_records_hit():
     session_factory = FakeSessionFactory()
     provider = CloudflareProvider(session_factory=session_factory)
     target = _target(include=None)
-    cache = _SingleFlightCache()
+    cache = SingleFlightCache()
     first_benchmark = {}
     second_benchmark = {}
 
@@ -450,7 +451,7 @@ def test_cloudflare_preflight_reuses_cache_and_records_hit():
 def test_cloudflare_preflight_cache_is_partitioned_by_zone_account():
     session_factory = FakeSessionFactory()
     provider = CloudflareProvider(session_factory=session_factory)
-    cache = _SingleFlightCache()
+    cache = SingleFlightCache()
 
     for account_id in (ACCOUNT_A, ACCOUNT_B):
         target = _target(
@@ -486,7 +487,7 @@ def test_cloudflare_preflight_cache_single_flights_concurrent_discovery():
     provider = CloudflareProvider(session_factory=session_factory)
     target = _target(include=None)
 
-    class TrackingCache(_SingleFlightCache):
+    class TrackingCache(SingleFlightCache):
         def __init__(self):
             super().__init__()
             self.calls = 0
@@ -538,7 +539,7 @@ def test_cloudflare_preflight_does_not_cache_discovery_failures():
     session_factory = FlakyFactory()
     provider = CloudflareProvider(session_factory=session_factory)
     target = _target(include=None)
-    cache = _SingleFlightCache()
+    cache = SingleFlightCache()
 
     with pytest.raises(RuntimeError, match="temporary discovery failure"):
         provider.prepare_target(

--- a/tests/runner/test_runner_flow.py
+++ b/tests/runner/test_runner_flow.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import threading
 from collections import deque
 from types import SimpleNamespace
 
@@ -17,13 +16,13 @@ from anvil.results import EntityResult, EngineState, ExecutionStatus
 from anvil.runner import (
     AuthCheckCache,
     PreparedTarget,
-    _SingleFlightCache,
     _execute_provider_targets,
     _next_eligible_target,
     prepare_target,
     run_multiple_targets,
     run_prepared_target,
 )
+from anvil.singleflight import SingleFlightCache
 from anvil.task_loader import ResolvedExecution, ResolvedTask
 
 
@@ -308,7 +307,7 @@ def test_prepare_target_carries_provider_preflight_and_execution_controls(monkey
         cli_dry_run=True,
         cli_include=None,
         cli_exclude=None,
-        preparation_cache=_SingleFlightCache(),
+        preparation_cache=SingleFlightCache(),
         auth_cache=AuthCheckCache(),
     )
 
@@ -332,7 +331,7 @@ def test_prepare_target_reports_provider_filter_errors_as_config_auth_results(
         cli_dry_run=None,
         cli_include=None,
         cli_exclude=["b"],
-        preparation_cache=_SingleFlightCache(),
+        preparation_cache=SingleFlightCache(),
         auth_cache=AuthCheckCache(),
     )
 
@@ -351,7 +350,7 @@ def test_run_prepared_target_passes_opaque_preflight_to_provider(monkeypatch):
         cli_dry_run=None,
         cli_include=None,
         cli_exclude=None,
-        preparation_cache=_SingleFlightCache(),
+        preparation_cache=SingleFlightCache(),
         auth_cache=AuthCheckCache(),
     )
 
@@ -407,63 +406,6 @@ def test_scheduler_skips_targets_with_overlapping_provider_keys():
 
     assert selected is eligible
     assert list(pending) == [blocked]
-
-
-def test_single_flight_cache_shares_concurrent_work():
-    cache = _SingleFlightCache()
-    started = threading.Event()
-    release = threading.Event()
-    calls = 0
-    results = []
-
-    def create():
-        nonlocal calls
-        calls += 1
-        started.set()
-        assert release.wait(timeout=1.0)
-        return "value"
-
-    def lookup():
-        results.append(cache.get_or_create(key="shared", create=create))
-
-    threads = [threading.Thread(target=lookup) for _ in range(2)]
-    for thread in threads:
-        thread.start()
-    assert started.wait(timeout=1.0)
-    release.set()
-    for thread in threads:
-        thread.join(timeout=1.0)
-
-    assert calls == 1
-    assert sorted(results) == [("value", False, False), ("value", True, True)]
-
-
-def test_single_flight_cache_releases_waiters_after_error():
-    cache = _SingleFlightCache()
-    started = threading.Event()
-    release = threading.Event()
-    errors = []
-
-    def create():
-        started.set()
-        assert release.wait(timeout=1.0)
-        raise ValueError("discovery failed")
-
-    def lookup():
-        try:
-            cache.get_or_create(key="shared", create=create)
-        except ValueError as error:
-            errors.append(str(error))
-
-    threads = [threading.Thread(target=lookup) for _ in range(2)]
-    for thread in threads:
-        thread.start()
-    assert started.wait(timeout=1.0)
-    release.set()
-    for thread in threads:
-        thread.join(timeout=1.0)
-
-    assert errors == ["discovery failed", "discovery failed"]
 
 
 def test_fail_fast_does_not_start_pending_execution_targets(monkeypatch):

--- a/tests/task_redesign/test_provider_and_preservation_contract.py
+++ b/tests/task_redesign/test_provider_and_preservation_contract.py
@@ -105,9 +105,9 @@ def test_aws_rejects_ambiguous_configured_target_before_runtime() -> None:
         )
 
 
-def test_aws_declares_configured_target_capability() -> None:
+def test_aws_declares_supported_task_scopes() -> None:
     assert AwsProvider.metadata.supported_task_scopes == frozenset(
-        {"configured_target", "region"}
+        {"configured_target", "target", "region"}
     )
 
 

--- a/tests/task_redesign/test_provider_and_preservation_contract.py
+++ b/tests/task_redesign/test_provider_and_preservation_contract.py
@@ -23,12 +23,12 @@ from anvil.results import AuthResult, ExecutionStatus
 from anvil.runner import (
     AuthCheckCache,
     PreparedTarget,
-    _SingleFlightCache,
     _execute_provider_execution_target,
     _execute_provider_targets,
     prepare_target,
     run_prepared_target,
 )
+from anvil.singleflight import SingleFlightCache
 from anvil.task_loader import ResolvedTask, TaskScope, discover_tasks
 
 
@@ -149,7 +149,7 @@ def test_aws_ambiguous_configured_target_stops_before_auth_and_preflight(
         cli_dry_run=None,
         cli_include=None,
         cli_exclude=None,
-        preparation_cache=_SingleFlightCache(),
+        preparation_cache=SingleFlightCache(),
         auth_cache=AuthCheckCache(),
     )
 
@@ -225,7 +225,7 @@ def test_configured_target_ambiguity_is_rejected_before_authentication(
         cli_dry_run=None,
         cli_include=None,
         cli_exclude=None,
-        preparation_cache=_SingleFlightCache(),
+        preparation_cache=SingleFlightCache(),
         auth_cache=AuthCheckCache(),
     )
 
@@ -264,7 +264,7 @@ def test_unsupported_scope_resolution_fails_before_authentication(
         cli_dry_run=None,
         cli_include=None,
         cli_exclude=None,
-        preparation_cache=_SingleFlightCache(),
+        preparation_cache=SingleFlightCache(),
         auth_cache=AuthCheckCache(),
     )
 
@@ -304,7 +304,7 @@ def test_ordinary_configuration_does_not_call_configured_validation_hook(
         cli_dry_run=None,
         cli_include=None,
         cli_exclude=None,
-        preparation_cache=_SingleFlightCache(),
+        preparation_cache=SingleFlightCache(),
         auth_cache=AuthCheckCache(),
     )
 

--- a/tests/tasks/test_task_helpers.py
+++ b/tests/tasks/test_task_helpers.py
@@ -1,0 +1,67 @@
+from types import MappingProxyType
+
+import pytest
+
+from anvil.providers.tasks._task_helpers import (
+    metadata_bool,
+    metadata_int,
+    metadata_string,
+    metadata_string_array,
+)
+
+
+def test_metadata_helpers_accept_read_only_mappings_and_normalize_values() -> None:
+    metadata = MappingProxyType(
+        {
+            "enabled": True,
+            "maximum": 5,
+            "name": "  example  ",
+            "users": [" alice ", "bob", "alice"],
+        }
+    )
+
+    assert metadata_bool(
+        task_name="example", metadata=metadata, key="enabled", default=False
+    )
+    assert (
+        metadata_int(task_name="example", metadata=metadata, key="maximum", default=10)
+        == 5
+    )
+    assert (
+        metadata_string(
+            task_name="example", metadata=metadata, key="name", required=True
+        )
+        == "example"
+    )
+    assert metadata_string_array(
+        task_name="example", metadata=metadata, key="users", required=True
+    ) == ["alice", "bob"]
+
+
+@pytest.mark.parametrize("value", [True, 0, 11, "5"])
+def test_metadata_int_rejects_boolean_type_and_out_of_bounds(value: object) -> None:
+    with pytest.raises(RuntimeError, match=r"example metadata\.maximum"):
+        metadata_int(
+            task_name="example",
+            metadata={"maximum": value},
+            key="maximum",
+            default=5,
+            minimum=1,
+            maximum=10,
+        )
+
+
+def test_required_metadata_helpers_reject_missing_values() -> None:
+    with pytest.raises(RuntimeError, match=r"metadata\.name"):
+        metadata_string(task_name="example", metadata={}, key="name", required=True)
+    with pytest.raises(RuntimeError, match=r"metadata\.users"):
+        metadata_string_array(
+            task_name="example", metadata={}, key="users", required=True
+        )
+
+
+def test_metadata_bool_rejects_non_boolean_values() -> None:
+    with pytest.raises(RuntimeError, match=r"example metadata\.enabled"):
+        metadata_bool(
+            task_name="example", metadata={"enabled": 1}, key="enabled", default=False
+        )

--- a/tests/test_filename_utils.py
+++ b/tests/test_filename_utils.py
@@ -1,0 +1,16 @@
+import pytest
+
+from anvil.filename_utils import safe_filename_component
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("org/account", "org_account"),
+        ("report-2026.08_json", "report-2026.08_json"),
+        ("._hidden_.", "hidden"),
+        ("...", "target"),
+    ],
+)
+def test_safe_filename_component_uses_canonical_rules(name: str, expected: str) -> None:
+    assert safe_filename_component(name) == expected

--- a/tests/test_singleflight.py
+++ b/tests/test_singleflight.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import threading
+
+from anvil.singleflight import SingleFlightCache
+
+
+def _join_threads(threads: list[threading.Thread]) -> None:
+    for thread in threads:
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
+
+
+def test_single_flight_cache_shares_concurrent_work() -> None:
+    cache = SingleFlightCache[str, str]()
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+    results: list[tuple[str, bool, bool]] = []
+
+    def create() -> str:
+        nonlocal calls
+        calls += 1
+        started.set()
+        assert release.wait(timeout=1.0)
+        return "value"
+
+    def lookup() -> None:
+        results.append(cache.get_or_create(key="shared", create=create))
+
+    threads = [threading.Thread(target=lookup) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    assert started.wait(timeout=1.0)
+    release.set()
+    _join_threads(threads)
+
+    assert calls == 1
+    assert sorted(results) == [("value", False, False), ("value", True, True)]
+
+
+def test_single_flight_cache_releases_waiters_after_error_and_allows_retry() -> None:
+    cache = SingleFlightCache[str, str]()
+    started = threading.Event()
+    release = threading.Event()
+    errors: list[str] = []
+
+    def fail() -> str:
+        started.set()
+        assert release.wait(timeout=1.0)
+        raise ValueError("discovery failed")
+
+    def lookup() -> None:
+        try:
+            cache.get_or_create(key="shared", create=fail)
+        except ValueError as error:
+            errors.append(str(error))
+
+    threads = [threading.Thread(target=lookup) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    assert started.wait(timeout=1.0)
+    release.set()
+    _join_threads(threads)
+
+    assert errors == ["discovery failed", "discovery failed"]
+    assert cache.get_or_create(key="shared", create=lambda: "recovered") == (
+        "recovered",
+        False,
+        False,
+    )
+
+
+def test_single_flight_cache_distinguishes_completed_hits_from_waiters() -> None:
+    cache = SingleFlightCache[str, str]()
+
+    assert cache.get_or_create(key="shared", create=lambda: "value") == (
+        "value",
+        False,
+        False,
+    )
+    assert cache.get_or_create(key="shared", create=lambda: "unexpected") == (
+        "value",
+        True,
+        False,
+    )
+
+
+def test_single_flight_cache_can_cache_none() -> None:
+    cache = SingleFlightCache[str, None]()
+    calls = 0
+
+    def create() -> None:
+        nonlocal calls
+        calls += 1
+
+    assert cache.get_or_create(key="shared", create=create) == (None, False, False)
+    assert cache.get_or_create(key="shared", create=create) == (None, True, False)
+    assert calls == 1
+
+
+def test_single_flight_cache_allows_different_keys_to_create_concurrently() -> None:
+    cache = SingleFlightCache[str, str]()
+    first_started = threading.Event()
+    second_started = threading.Event()
+    release = threading.Event()
+    results: list[tuple[str, bool, bool]] = []
+
+    def create(value: str, started: threading.Event) -> str:
+        started.set()
+        assert release.wait(timeout=1.0)
+        return value
+
+    threads = [
+        threading.Thread(
+            target=lambda: results.append(
+                cache.get_or_create(
+                    key="first", create=lambda: create("first", first_started)
+                )
+            )
+        ),
+        threading.Thread(
+            target=lambda: results.append(
+                cache.get_or_create(
+                    key="second", create=lambda: create("second", second_started)
+                )
+            )
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+    assert first_started.wait(timeout=1.0)
+    assert second_started.wait(timeout=1.0)
+    release.set()
+    _join_threads(threads)
+
+    assert sorted(results) == [("first", False, False), ("second", False, False)]

--- a/yaml/get_aws_inline_policies.yaml
+++ b/yaml/get_aws_inline_policies.yaml
@@ -1,0 +1,13 @@
+schema_version: 2
+targets:
+  - name: aws-accounts
+    provider:
+      name: aws
+      mode: organization
+      options:
+        profile: payer-profile
+    regions: [us-east-1]
+    tasks:
+      - name: get_aws_inline_policies
+        metadata:
+          types: [user, role, group]

--- a/yaml/get_aws_sso_inline_policies.yaml
+++ b/yaml/get_aws_sso_inline_policies.yaml
@@ -1,0 +1,13 @@
+schema_version: 2
+targets:
+  - name: aws-organization
+    provider:
+      name: aws
+      mode: organization
+      options:
+        profile: payer-profile
+    regions: [us-east-1]
+    tasks:
+      - name: get_aws_sso_inline_policies
+        metadata:
+          identity_center_region: us-west-2

--- a/yaml/orgs.yaml
+++ b/yaml/orgs.yaml
@@ -15,7 +15,7 @@ targets:
     dry_run: true
     max_workers: 5
     metadata:
-      user_name: migration
+      users: [migration]
   - name: org2
     provider:
       name: aws
@@ -29,4 +29,4 @@ targets:
     dry_run: true
     max_workers: 5
     metadata:
-      user_name: migration
+      users: [migration]


### PR DESCRIPTION
## Description
Several provider and runner paths maintained similar single-flight cache implementations. Centralizing this behavior reduces duplication and provides consistent handling for concurrent callers, cached values, failures, and retries.

The task-builder documentation also needed clearer scope guidance because task scope affects invocation count, result ownership, dependency mapping, and the safety of destructive operations.

- Add a reusable, typed `SingleFlightCache` for coordinating concurrent work by key.
- Replace duplicated caching implementations in the runner and Azure, GCP, and GitHub providers.
- Preserve cache-hit and waiter benchmark semantics while supporting cached `None` values.
- Store provider discovery results as immutable tuples and return defensive lists.
- Expand Anvil task-builder guidance for selecting `region`, `target`, and `configured_target` scopes based on resource ownership.


## Checklist
- [x] Python format, lint, and tests (`ruff` and `pytest`) were successful.
- [x] Pre-commit hooks passed locally.
- [x] Documentation updated if needed.
- [x] Unit tests added or updated.
